### PR TITLE
Stream posterior predictions by draw

### DIFF
--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -622,6 +622,101 @@ class JAXSEDFit:
         return {key: np.expand_dims(np.asarray(value), axis=0) for key, value in median_mapping(samples).items()}
 
     @staticmethod
+    def _prediction_draw_count(samples: Mapping[str, Any]) -> int:
+        """Return the common leading posterior-draw dimension."""
+        draw_counts = {
+            int(arr.shape[0])
+            for value in samples.values()
+            if (arr := np.asarray(value)).ndim > 0
+        }
+        if not draw_counts:
+            raise ValueError("Posterior samples do not contain a draw dimension.")
+        if len(draw_counts) != 1:
+            raise ValueError(
+                "Posterior sample sites must share one leading draw dimension; "
+                f"received {sorted(draw_counts)}."
+            )
+        draw_count = draw_counts.pop()
+        if draw_count < 1:
+            raise ValueError("Posterior samples contain no draws.")
+        return draw_count
+
+    def _stream_predictive_draws(
+        self,
+        samples: Mapping[str, Any],
+        *,
+        kind: str,
+        rng_key: Any,
+    ) -> dict[str, np.ndarray]:
+        """Evaluate posterior predictions one draw at a time.
+
+        NumPyro maps a multi-draw ``Predictive`` call through a compiled
+        ``lax.map``.  Large joint SED and spectrum models can require many
+        gigabytes while compiling and executing that map even when its output
+        is comparatively small.  Single-draw calls reuse one compiled model
+        executable and bound peak memory to one model evaluation plus the
+        returned host arrays.
+        """
+        draw_count = self._prediction_draw_count(samples)
+        rng_keys = (
+            (rng_key,)
+            if draw_count == 1
+            else tuple(jax.random.split(rng_key, draw_count))
+        )
+        include_components = kind == "plot"
+        model = lambda: grahsp_photometric_model(
+            self.context,
+            include_components=include_components,
+            force_component_fluxes=(kind == "photometry"),
+        )
+        return_sites = self._predictive_return_sites(kind)
+        streamed: dict[str, np.ndarray] | None = None
+
+        for draw_index, draw_rng_key in enumerate(rng_keys):
+            one_draw = {
+                key: (
+                    value
+                    if (arr := np.asarray(value)).ndim == 0
+                    else arr[draw_index : draw_index + 1]
+                )
+                for key, value in samples.items()
+            }
+            prediction = Predictive(
+                model,
+                posterior_samples=one_draw,
+                return_sites=return_sites,
+            )(draw_rng_key)
+            host_prediction = {key: np.asarray(value) for key, value in prediction.items()}
+
+            if streamed is None:
+                streamed = {}
+                for key, value in host_prediction.items():
+                    if value.ndim == 0 or value.shape[0] != 1:
+                        raise ValueError(
+                            "Single-draw Predictive outputs must have a leading "
+                            f"dimension of one; site {key!r} has shape {value.shape}."
+                        )
+                    streamed[key] = np.empty(
+                        (draw_count,) + value.shape[1:],
+                        dtype=value.dtype,
+                    )
+            elif set(host_prediction) != set(streamed):
+                raise ValueError(
+                    "Predictive site names changed between posterior draws."
+                )
+
+            for key, value in host_prediction.items():
+                expected_shape = (1,) + streamed[key].shape[1:]
+                if value.shape != expected_shape:
+                    raise ValueError(
+                        f"Predictive site {key!r} changed shape between draws: "
+                        f"expected {expected_shape}, received {value.shape}."
+                    )
+                streamed[key][draw_index] = value[0]
+
+        return {} if streamed is None else streamed
+
+    @staticmethod
     def _predictive_return_sites(kind: str) -> list[str]:
         """Return deterministic sites needed for a prediction product set.
 
@@ -867,19 +962,13 @@ class JAXSEDFit:
         cache_key = f"{kind}:{'all' if max_draws is None else int(max_draws)}"
         if cache and posterior_samples is None and state.predictive_cache is not None and cache_key in state.predictive_cache:
             return dict(state.predictive_cache[cache_key])
-        include_components = kind == "plot"
         draw_samples = self._subset_prediction_samples(samples, max_draws)
         rng_key = jax.random.PRNGKey(self.config.inference.seed + 17)
-        pred = Predictive(
-            lambda: grahsp_photometric_model(
-                self.context,
-                include_components=include_components,
-                force_component_fluxes=(kind == "photometry"),
-            ),
-            posterior_samples=draw_samples,
-            return_sites=self._predictive_return_sites(kind),
-        )(rng_key)
-        predictive = {k: np.asarray(v) for k, v in pred.items()}
+        predictive = self._stream_predictive_draws(
+            draw_samples,
+            kind=kind,
+            rng_key=rng_key,
+        )
         if cache and posterior_samples is None:
             if state.predictive_cache is None:
                 state.predictive_cache = {}

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -453,6 +453,10 @@ def test_grouped_trace_samples_hide_internal_reparameterization_sites():
 def test_jaxsedfit_corner_and_trace_methods_delegate(monkeypatch):
     import jaxsedfit.plotting as plotting
 
+    missing = object()
+    package = sys.modules["jaxsedfit"]
+    original_core_module = sys.modules.get("jaxsedfit.core", missing)
+    original_core_attribute = getattr(package, "core", missing)
     model = types.ModuleType("jaxsedfit.model")
     model.grahsp_photometric_model = lambda *args, **kwargs: None
     preload = types.ModuleType("jaxsedfit.preload")
@@ -502,4 +506,12 @@ def test_jaxsedfit_corner_and_trace_methods_delegate(monkeypatch):
         assert calls["trace"][0] is fitter
         assert calls["trace"][1]["output_path"] == "result_trace.pdf"
     finally:
-        sys.modules.pop("jaxsedfit.core", None)
+        if original_core_module is missing:
+            sys.modules.pop("jaxsedfit.core", None)
+        else:
+            sys.modules["jaxsedfit.core"] = original_core_module
+        if original_core_attribute is missing:
+            if hasattr(package, "core"):
+                delattr(package, "core")
+        else:
+            package.core = original_core_attribute

--- a/tests/test_predictive_streaming.py
+++ b/tests/test_predictive_streaming.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpyro
+import numpyro.distributions as dist
+import pytest
+from numpyro.infer import Predictive
+
+from jaxsedfit.core import JAXSEDFit
+from jaxsedfit.results import _FitState
+
+
+def _bare_fitter(samples, *, seed=3):
+    fitter = object.__new__(JAXSEDFit)
+    fitter.config = SimpleNamespace(inference=SimpleNamespace(seed=seed))
+    fitter.context = SimpleNamespace()
+    fitter._fit_state = _FitState(samples=samples)
+    return fitter
+
+
+def _small_model(context, *, include_components=False, force_component_fluxes=False):
+    del context, include_components, force_component_fluxes
+    theta = numpyro.sample("theta", dist.Normal(0.0, 1.0))
+    scatter = numpyro.sample("scatter", dist.Normal(theta, 0.1))
+    numpyro.deterministic("pred_fluxes", jnp.asarray([theta, 2.0 * theta]))
+    numpyro.deterministic("sed_chi2", theta**2)
+    numpyro.deterministic("scattered_flux", scatter)
+
+
+def test_streamed_predictive_matches_numpyro_bulk_prediction(monkeypatch):
+    samples = {"theta": np.asarray([0.5, 1.5, -2.0])}
+    fitter = _bare_fitter(samples, seed=11)
+    monkeypatch.setattr("jaxsedfit.core.grahsp_photometric_model", _small_model)
+    monkeypatch.setattr(
+        fitter,
+        "_predictive_return_sites",
+        lambda kind: ["pred_fluxes", "sed_chi2", "scattered_flux"],
+    )
+
+    rng_key = jax.random.PRNGKey(fitter.config.inference.seed + 17)
+    expected = Predictive(
+        lambda: _small_model(None),
+        posterior_samples=samples,
+        return_sites=["pred_fluxes", "sed_chi2", "scattered_flux"],
+    )(rng_key)
+
+    actual = fitter.predict(kind="photometry")
+
+    assert set(actual) == set(expected)
+    for key in expected:
+        np.testing.assert_allclose(
+            actual[key],
+            np.asarray(expected[key]),
+            rtol=1.0e-14,
+            atol=0.0,
+        )
+
+
+def test_streamed_predictive_calls_numpyro_once_per_draw(monkeypatch):
+    samples = {
+        "theta": np.asarray([1.0, 2.0, 3.0]),
+        "fixed": np.asarray(4.0),
+    }
+    fitter = _bare_fitter(samples, seed=7)
+    calls = []
+
+    class FakePredictive:
+        def __init__(self, model, *, posterior_samples, return_sites):
+            del model, return_sites
+            self.posterior_samples = posterior_samples
+
+        def __call__(self, rng_key):
+            theta = np.asarray(self.posterior_samples["theta"])
+            calls.append(
+                {
+                    "rng_key": np.asarray(rng_key),
+                    "theta": theta.copy(),
+                    "fixed": np.asarray(self.posterior_samples["fixed"]).copy(),
+                }
+            )
+            return {
+                "pred_fluxes": np.stack((theta, 2.0 * theta), axis=-1),
+                "sed_chi2": theta**2,
+            }
+
+    monkeypatch.setattr("jaxsedfit.core.Predictive", FakePredictive)
+
+    prediction = fitter.predict(kind="photometry")
+
+    assert len(calls) == 3
+    expected_keys = np.asarray(
+        jax.random.split(jax.random.PRNGKey(fitter.config.inference.seed + 17), 3)
+    )
+    for index, call in enumerate(calls):
+        assert call["theta"].shape == (1,)
+        np.testing.assert_array_equal(call["theta"], [samples["theta"][index]])
+        np.testing.assert_array_equal(call["fixed"], samples["fixed"])
+        np.testing.assert_array_equal(call["rng_key"], expected_keys[index])
+    np.testing.assert_array_equal(
+        prediction["pred_fluxes"],
+        [[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]],
+    )
+    np.testing.assert_array_equal(prediction["sed_chi2"], [1.0, 4.0, 9.0])
+
+    cached = fitter.predict(kind="photometry")
+    assert len(calls) == 3
+    np.testing.assert_array_equal(cached["pred_fluxes"], prediction["pred_fluxes"])
+
+
+def test_single_draw_prediction_preserves_unsplit_rng_key(monkeypatch):
+    fitter = _bare_fitter({"theta": np.asarray([2.0])}, seed=5)
+    observed_keys = []
+
+    class FakePredictive:
+        def __init__(self, model, *, posterior_samples, return_sites):
+            del model, return_sites
+            self.posterior_samples = posterior_samples
+
+        def __call__(self, rng_key):
+            observed_keys.append(np.asarray(rng_key))
+            return {"pred_fluxes": np.asarray(self.posterior_samples["theta"])[:, None]}
+
+    monkeypatch.setattr("jaxsedfit.core.Predictive", FakePredictive)
+
+    fitter.predict(kind="photometry")
+
+    np.testing.assert_array_equal(
+        observed_keys[0],
+        np.asarray(jax.random.PRNGKey(fitter.config.inference.seed + 17)),
+    )
+
+
+def test_streamed_predictive_rejects_inconsistent_draw_dimensions():
+    fitter = _bare_fitter(
+        {
+            "theta": np.asarray([1.0, 2.0]),
+            "scale": np.asarray([1.0, 2.0, 3.0]),
+        }
+    )
+
+    with pytest.raises(ValueError, match="share one leading draw dimension"):
+        fitter.predict(kind="photometry")


### PR DESCRIPTION
## Summary

- evaluate posterior predictive products one posterior draw at a time
- reuse the single-draw compiled model while preallocating final host arrays
- preserve NumPyro's original per-draw RNG splitting, output shapes, caching, prediction kinds, and `max_draws` behavior
- validate draw dimensions and fail clearly if predictive sites or shapes change between draws

## Why

NumPyro's multi-draw `Predictive` path enters a compiled `lax.map` for this model. For joint SED and 3,840-pixel spectrum predictions, that path had a much larger compilation and execution peak than either the returned arrays or a single model evaluation required.

On a real 250-draw joint-fit bundle, the existing call peaked at 13.61 GB. The streamed implementation retained all 250 draws and the same 119 MB output payload while peaking at 1.86 GB. The streamed prediction completed in 23.6 seconds in the focused local probe.

## Behavior

This does not reduce or subsample the posterior. Each draw is evaluated with the same RNG key it receives in NumPyro's bulk prediction. Results are written directly into preallocated NumPy arrays, avoiding a second concatenation-sized allocation.

## Validation

- 227 focused model, predictive, plotting, persistence, Diffstar, and helper tests passed
- numerical equivalence test against NumPyro bulk prediction, including an unconditioned stochastic site
- one-call-per-draw, RNG splitting, cache reuse, single-draw RNG, and invalid-shape regression tests
- real 250-draw joint SED+spectrum memory probe: 13.61 GB to 1.86 GB peak RSS
- Python compilation and `git diff --check` passed

