### PR TITLE
Add PSF and synthetic photometry to spectral figures

### DIFF
--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -2168,6 +2168,69 @@ class JAXSEDFit:
         flux_lambda_obs = np.asarray(flux_lambda_obs, dtype=float)
         return flux_lambda_obs * 1.0e3 * (1.0 + float(redshift)) / 1.0e-17
 
+    def _sdss_psf_photometry_for_spectral_plot(
+        self,
+    ) -> tuple[list[str], np.ndarray, np.ndarray]:
+        """Return valid SDSS PSF photometry in the plotting API's AB units.
+
+        The model context stores the photometry used by the fit in mJy,
+        including any configured Milky Way dereddening.  The shared
+        PyQSOFit-style spectral plotter instead accepts ``psf_mags`` and
+        ``psf_mag_errs``, so convert only native ugriz PSF measurements and
+        retain their canonical band order.
+        """
+        photometry = getattr(self.config, "photometry", None)
+        if photometry is None or getattr(photometry, "photometry_method", None) is None:
+            return [], np.asarray([], dtype=float), np.asarray([], dtype=float)
+
+        filter_names = np.asarray(getattr(photometry, "filter_names", []), dtype=object)
+        methods = np.asarray(photometry.photometry_method, dtype=object)
+        fluxes = np.asarray(getattr(self.context, "fluxes", []), dtype=float)
+        errors = np.asarray(getattr(self.context, "errors", []), dtype=float)
+        data_mask = np.asarray(
+            getattr(self.context, "data_mask", np.ones(fluxes.shape, dtype=bool)),
+            dtype=bool,
+        )
+        sizes = {filter_names.size, methods.size, fluxes.size, errors.size, data_mask.size}
+        if len(sizes) != 1:
+            raise ValueError("Photometry metadata and model-context arrays must have matching lengths.")
+
+        bands: list[str] = []
+        magnitudes: list[float] = []
+        magnitude_errors: list[float] = []
+        for band in ("u", "g", "r", "i", "z"):
+            matches = np.flatnonzero(
+                (filter_names == f"{band}_sdss")
+                & (methods == "psf")
+            )
+            if matches.size > 1:
+                raise ValueError(
+                    f"Expected at most one PSF measurement for filter '{band}_sdss'; "
+                    f"found {matches.size}."
+                )
+            if matches.size == 0:
+                continue
+            idx = int(matches[0])
+            flux_mjy = float(fluxes[idx])
+            error_mjy = float(errors[idx])
+            if (
+                not data_mask[idx]
+                or not np.isfinite(flux_mjy)
+                or not np.isfinite(error_mjy)
+                or flux_mjy <= 0.0
+                or error_mjy <= 0.0
+            ):
+                continue
+            bands.append(band)
+            magnitudes.append(-2.5 * np.log10(flux_mjy * 1.0e-26) - 48.60)
+            magnitude_errors.append((2.5 / np.log(10.0)) * error_mjy / flux_mjy)
+
+        return (
+            bands,
+            np.asarray(magnitudes, dtype=float),
+            np.asarray(magnitude_errors, dtype=float),
+        )
+
     def plot_jaxqsofit_spectrum(
         self,
         spectrum_index: int = 0,
@@ -2490,7 +2553,11 @@ class JAXSEDFit:
                 if band is not None:
                     pred_bands[name] = band
         plotter.pred_bands = pred_bands
-        plotter.use_psf_phot = False
+        psf_bands, psf_mags, psf_mag_errs = self._sdss_psf_photometry_for_spectral_plot()
+        plotter.use_psf_phot = bool(psf_bands)
+        plotter.psf_bands = psf_bands
+        plotter.psf_mags = psf_mags
+        plotter.psf_mag_errs = psf_mag_errs
         plotter.psf_model = np.array([])
         plotter.host_psf = np.array([])
         plotter.scale_psf = 1.0

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -880,11 +880,11 @@ def plot_fit_sed(
             ax_resid.text(
                 0.98,
                 0.05,
-                rf"$\mathrm{{median}}(\chi^2/N_\mathrm{{eff}}) = {reduced_chi2:.2f}$",
+                rf"$\chi^2_\nu = {reduced_chi2:.2f}$",
                 transform=ax_resid.transAxes,
                 va="bottom",
                 ha="right",
-                color="#c53030",
+                color="black",
                 fontsize=10,
             )
 

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -2483,6 +2483,10 @@ def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):
         captured["custom_components"] = dict(self.custom_components)
         captured["custom_line_components"] = dict(self.custom_line_components)
         captured["pred_bands"] = self.pred_bands
+        captured["use_psf_phot"] = self.use_psf_phot
+        captured["psf_bands"] = list(self.psf_bands)
+        captured["psf_mags"] = np.asarray(self.psf_mags)
+        captured["psf_mag_errs"] = np.asarray(self.psf_mag_errs)
         captured["kwargs"] = kwargs
         self.fig = "fig"
 
@@ -2492,8 +2496,15 @@ def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):
     fitter.config = SimpleNamespace(
         observation=SimpleNamespace(object_id="obj", redshift=1.0),
         spectroscopy_config=SimpleNamespace(backend="jaxqsofit"),
+        photometry=SimpleNamespace(
+            filter_names=["W1", "r_sdss", "u_sdss", "g_sdss", "z_sdss", "i_sdss"],
+            photometry_method=["catalog", "psf", "psf", "catalog", "psf", "psf"],
+        ),
     )
     fitter.context = SimpleNamespace(
+        fluxes=np.asarray([1.0, 2.0, 4.0, 3.0, 5.0, -1.0]),
+        errors=np.asarray([0.1, 0.2, 0.8, 0.3, 0.5, 0.1]),
+        data_mask=np.asarray([True, True, True, True, False, True]),
         spec_wave_obs=np.asarray([4000.0, 5000.0, 6000.0]),
         spec_fluxes=np.asarray([1.0, 2.0, 3.0]),
         spec_errors=np.asarray([0.1, 0.2, 0.3]),
@@ -2564,6 +2575,16 @@ def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):
     assert "jaxsedfit_torus" in captured["pred_bands"]
     assert "broad_lines" in captured["pred_bands"]
     assert "narrow_lines" in captured["pred_bands"]
+    assert captured["use_psf_phot"] is True
+    assert captured["psf_bands"] == ["u", "r"]
+    np.testing.assert_allclose(
+        captured["psf_mags"],
+        -2.5 * np.log10(np.asarray([4.0, 2.0]) * 1.0e-26) - 48.60,
+    )
+    np.testing.assert_allclose(
+        captured["psf_mag_errs"],
+        (2.5 / np.log(10.0)) * np.asarray([0.8 / 4.0, 0.2 / 2.0]),
+    )
     lo, hi = captured["pred_bands"]["total_model"]
     assert lo.shape == captured["wave"].shape
     assert hi.shape == captured["wave"].shape
@@ -2577,6 +2598,52 @@ def test_plot_jaxqsofit_spectrum_adapts_joint_predictive(monkeypatch):
     assert "jaxsedfit_sed_lines" not in captured["custom_components"]
     assert np.nanmax(captured["custom_components"]["jaxsedfit_nebular_lines"]) > 0.0
     assert "jaxsedfit_nebular_lines" in captured["pred_bands"]
+
+
+def test_spectral_plot_psf_photometry_rejects_duplicate_band():
+    fitter = JAXSEDFit.__new__(JAXSEDFit)
+    fitter.config = SimpleNamespace(
+        photometry=SimpleNamespace(
+            filter_names=["u_sdss", "u_sdss"],
+            photometry_method=["psf", "psf"],
+        )
+    )
+    fitter.context = SimpleNamespace(
+        fluxes=np.asarray([1.0, 2.0]),
+        errors=np.asarray([0.1, 0.2]),
+        data_mask=np.asarray([True, True]),
+    )
+
+    with pytest.raises(ValueError, match="at most one PSF measurement.*u_sdss"):
+        fitter._sdss_psf_photometry_for_spectral_plot()
+
+
+def test_spectral_plot_photometry_helpers_return_observed_and_synthetic_points():
+    from jaxsedfit.spectral_plotting import (
+        observed_photometry_for_plot,
+        synthetic_photometry_for_plot,
+    )
+
+    plotter = SimpleNamespace(
+        use_psf_phot=True,
+        psf_bands=list("ugriz"),
+        psf_mags=np.asarray([20.0, 19.5, 19.0, 18.5, 18.0]),
+        psf_mag_errs=np.full(5, 0.1),
+        z=0.5,
+        wave=np.linspace(1800.0, 8000.0, 5000),
+        model_total=np.full(5000, 10.0),
+    )
+
+    observed = observed_photometry_for_plot(plotter)
+    synthetic = synthetic_photometry_for_plot(plotter)
+
+    assert observed is not None
+    assert synthetic is not None
+    for points in (observed, synthetic):
+        assert all(np.asarray(values).shape == (5,) for values in points)
+        assert all(np.all(np.isfinite(values)) for values in points)
+    assert np.all(observed[2] > 0.0)
+    assert np.all(synthetic[2] > 0.0)
 
 
 def test_config_rejects_invalid_redshift_pdf():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -212,7 +212,12 @@ def test_plot_fit_sed_uses_likelihood_photometry_and_saved_chi2():
         if container.get_label() == "Observed photometry"
     )
     np.testing.assert_allclose(observed.lines[0].get_ydata(), context.fluxes)
-    assert any("2.00" in text.get_text() for text in fig.axes[1].texts)
+    chi2_labels = [
+        text for text in fig.axes[1].texts if r"\chi^2_\nu" in text.get_text()
+    ]
+    assert len(chi2_labels) == 1
+    assert chi2_labels[0].get_text() == r"$\chi^2_\nu = 2.00$"
+    assert chi2_labels[0].get_color() == "black"
 
 
 def test_median_effective_variance_matches_nebular_and_lyman_terms():


### PR DESCRIPTION
## Summary
- pass fitted SDSS PSF photometry into joint spectral figures in canonical ugriz order
- convert the likelihood photometry from mJy to PyQSOFit-style AB magnitudes and propagated magnitude uncertainties
- overlay observed PSF photometry and matching synthetic SDSS photometry on joint-fit spectral plots
- reject ambiguous duplicate per-band PSF inputs and skip invalid, masked, or non-PSF measurements
- render the SED residual-panel diagnostic as black `\chi^2_\nu` text instead of the previous red `median(\chi^2/N_eff)` label, without changing the saved diagnostic value

## Why
The joint-fit spectral adapter previously disabled the plotting interface’s existing PSF-photometry support, so joint spectral figures omitted both observed and synthetic broadband points. This change connects the fitted, Milky-Way-dereddened photometry to that interface and uses conventional reduced-chi-square notation in the SED figure.

## Validation
- full suite: `417 passed, 6 skipped`
- focused plotting and model-helper suites: `135 passed`
- regression coverage for ugriz selection, mJy-to-AB conversion, magnitude-error propagation, duplicate-band rejection, observed and synthetic photometry generation, and exact chi-square label text/color
- `git diff --check`