### PR TITLE
Complete PredictionResult mapping API

### DIFF
--- a/src/jaxsedfit/results.py
+++ b/src/jaxsedfit/results.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 import numpy as np
 
@@ -46,7 +47,7 @@ class _FitState:
 
 
 @dataclass
-class PredictionResult:
+class PredictionResult(Mapping[str, Any]):
     """Dict-like posterior predictive result with lazy median summaries."""
 
     data: Mapping[str, Any]
@@ -69,6 +70,12 @@ class PredictionResult:
             Predictive site name to retrieve.
         """
         return self.data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.data)
+
+    def __len__(self) -> int:
+        return len(self.data)
 
     def keys(self):
         return self.data.keys()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,23 @@
+from collections.abc import Mapping
+
+import numpy as np
+
+from jaxsedfit.results import PredictionResult
+
+
+def test_prediction_result_satisfies_mapping_contract():
+    data = {
+        "pred_fluxes": np.array([[1.0], [3.0]]),
+        "sed_chi2": np.array([1.0, 9.0]),
+    }
+    prediction = PredictionResult(data, fitter=None)
+
+    assert isinstance(prediction, Mapping)
+    assert "pred_fluxes" in prediction
+    assert "missing" not in prediction
+    assert list(prediction) == list(data)
+    assert len(prediction) == len(data)
+    assert prediction.keys() == data.keys()
+    assert prediction.get("missing") is None
+    np.testing.assert_array_equal(prediction["sed_chi2"], data["sed_chi2"])
+    np.testing.assert_array_equal(prediction.median["pred_fluxes"], [2.0])


### PR DESCRIPTION
## Summary

- make `PredictionResult` implement `collections.abc.Mapping`
- delegate iteration and length to the wrapped prediction data
- add regression coverage for membership, iteration, length, indexing, key access, and median summaries

## Root cause

`PredictionResult` exposed `__getitem__` without the complete mapping protocol. Python therefore evaluated membership through legacy sequence-style indexing and attempted key `0`, producing `KeyError: 0` in consumers using `name in prediction`.

## Impact

`PredictionResult` now behaves as its documented dictionary-like API promises. Existing indexing, `keys()`, `items()`, `get()`, and lazy median behavior are preserved.

## Validation

- `16 passed` in `tests/test_results.py tests/test_plotting.py` under `jaxcpu5_sdev`
- QVC integration suite: `14 passed`
- direct reproduction confirms mapping membership and joint chi-square summarization
