### PR TITLE
Document the complete filter registry

### DIFF
--- a/docs/_ext/filter_registry.py
+++ b/docs/_ext/filter_registry.py
@@ -1,0 +1,127 @@
+"""Render the complete packaged filter registry in the Sphinx documentation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from html import escape
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+
+_FAMILY_LABELS = {
+    "2mass": "2MASS",
+    "cfht": "CFHT",
+    "ctio": "CTIO",
+    "euclid": "Euclid",
+    "galex": "GALEX",
+    "generic": "Generic photometric systems",
+    "herschel": "Herschel",
+    "hst": "Hubble Space Telescope (HST)",
+    "jwst": "James Webb Space Telescope (JWST)",
+    "kpno": "KPNO",
+    "lasilla": "La Silla Observatory",
+    "noao": "NOAO",
+    "panstarrs": "Pan-STARRS",
+    "paranal": "Paranal Observatory",
+    "roman": "Nancy Grace Roman Space Telescope",
+    "rubin": "Vera C. Rubin Observatory",
+    "sloan": "Sloan Digital Sky Survey (SDSS)",
+    "spitzer": "Spitzer Space Telescope",
+    "subaru": "Subaru Telescope",
+    "ukirt": "UKIRT",
+    "wise": "WISE",
+}
+
+
+def _display_instrument(parts: list[str]) -> str:
+    if len(parts) <= 2:
+        return "—"
+    return " / ".join(part.replace("_", " ").upper() for part in parts[1:-1])
+
+
+def _registry_html() -> str:
+    from jaxsedfit.filters import (
+        FILTER_NAME_ALIASES,
+        load_filter_curve,
+        vendored_filter_registry,
+    )
+
+    aliases = defaultdict(list)
+    for alias, canonical in FILTER_NAME_ALIASES.items():
+        aliases[canonical].append(alias)
+
+    families = defaultdict(list)
+    for canonical in vendored_filter_registry():
+        parts = canonical.split(".")
+        curve = load_filter_curve(canonical)
+        families[parts[0]].append(
+            (
+                float(curve.effective_wavelength),
+                _display_instrument(parts),
+                parts[-1],
+                canonical,
+                tuple(sorted(aliases.get(canonical, ()))),
+            )
+        )
+
+    nav = "".join(
+        f'<a href="#filters-{escape(family)}">{escape(_FAMILY_LABELS.get(family, family.upper()))}</a>'
+        for family in sorted(families)
+    )
+    sections = []
+    for family in sorted(families):
+        rows = []
+        for pivot, instrument, filter_name, canonical, public_aliases in sorted(
+            families[family]
+        ):
+            alias_html = (
+                ", ".join(f"<code>{escape(alias)}</code>" for alias in public_aliases)
+                if public_aliases
+                else "—"
+            )
+            rows.append(
+                "<tr>"
+                f"<td>{escape(instrument)}</td>"
+                f"<td><code>{escape(filter_name)}</code></td>"
+                f"<td><code>{escape(canonical)}</code></td>"
+                f'<td class="numeric">{pivot:,.1f}</td>'
+                f"<td>{alias_html}</td>"
+                "</tr>"
+            )
+        label = _FAMILY_LABELS.get(family, family.upper())
+        sections.append(
+            f'<section class="filter-family" id="filters-{escape(family)}">'
+            f"<h2>{escape(label)} <span>({len(rows)} filters)</span></h2>"
+            '<div class="filter-table-scroll"><table class="filter-reference-table">'
+            "<thead><tr><th>Instrument / system</th><th>Filter</th>"
+            "<th>Canonical name</th><th>Pivot wavelength [Å]</th>"
+            "<th>Accepted aliases</th></tr></thead>"
+            f"<tbody>{''.join(rows)}</tbody></table></div></section>"
+        )
+
+    return (
+        '<div class="filter-reference">'
+        f'<p class="filter-count"><strong>{sum(map(len, families.values()))}</strong> canonical filters '
+        f"across <strong>{len(families)}</strong> telescope and survey families.</p>"
+        f'<nav class="filter-family-nav">{nav}</nav>{"".join(sections)}</div>'
+    )
+
+
+class FilterRegistryDirective(Directive):
+    """Insert all packaged filters grouped by telescope and instrument."""
+
+    has_content = False
+
+    def run(self):
+        return [nodes.raw("", _registry_html(), format="html")]
+
+
+def setup(app):
+    """Register the filter-registry directive with Sphinx."""
+    app.add_directive("filter-registry", FilterRegistryDirective)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_static/filter-reference.css
+++ b/docs/_static/filter-reference.css
@@ -1,0 +1,65 @@
+.filter-family-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 1rem 0 2rem;
+}
+
+.filter-family-nav a {
+  background: var(--pst-color-surface, #f3f4f6);
+  border: 1px solid var(--pst-color-border, #d1d5db);
+  border-radius: 0.35rem;
+  padding: 0.3rem 0.55rem;
+  text-decoration: none;
+}
+
+.filter-family {
+  margin-top: 2.2rem;
+  scroll-margin-top: 1rem;
+}
+
+.filter-family h2 span {
+  color: #6b7280;
+  font-size: 0.75em;
+  font-weight: normal;
+}
+
+.filter-table-scroll {
+  overflow-x: auto;
+}
+
+.filter-reference-table {
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  width: 100%;
+}
+
+.filter-reference-table th,
+.filter-reference-table td {
+  border-bottom: 1px solid var(--pst-color-border, #d9dee7);
+  padding: 0.38rem 0.55rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.filter-reference-table th {
+  background: var(--pst-color-surface, #eef2f7);
+  position: sticky;
+  top: 0;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.filter-reference-table tbody tr:nth-child(even) {
+  background: rgba(127, 127, 127, 0.06);
+}
+
+.filter-reference-table .numeric {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.filter-reference-table code {
+  white-space: nowrap;
+}

--- a/docs/api/filters.rst
+++ b/docs/api/filters.rst
@@ -1,6 +1,9 @@
 Filters Package
 ===============
 
+For the complete list of packaged passbands grouped by telescope and
+instrument, see :doc:`../filters`.
+
 .. currentmodule:: jaxsedfit
 
 .. autoclass:: FilterCurve

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,11 @@ from datetime import datetime
 
 ROOT = os.path.abspath("..")
 SRC = os.path.join(ROOT, "src")
+DOC_EXT = os.path.abspath("_ext")
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
+if DOC_EXT not in sys.path:
+    sys.path.insert(0, DOC_EXT)
 
 project = "JAXSEDFit"
 author = "JAXSEDFit contributors"
@@ -18,6 +21,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
+    "filter_registry",
     "nbsphinx",
     "nbsphinx_link",
 ]
@@ -56,6 +60,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
+html_css_files = ["filter-reference.css"]
 html_title = "JAXSEDFit Documentation"
 html_show_sourcelink = False
 html_theme_options = {

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -1,0 +1,104 @@
+Available telescopes and filters
+================================
+
+JAXSEDFit ships the filter transmission curves listed below. Pass the
+canonical name—or one of the displayed aliases—to
+:func:`jaxsedfit.filters.load_filter_curve`, or pass several names to
+:func:`jaxsedfit.filters.load_filter_curves`:
+
+.. code-block:: python
+
+   from jaxsedfit.filters import load_filter_curves
+
+   curves = load_filter_curves([
+       "galex.FUV",
+       "sloan.sdss.g",
+       "jwst.nircam.F444W",
+   ])
+
+The pivot wavelengths are calculated from the packaged transmission curves.
+This reference is generated directly from the filter registry during the
+documentation build, so every packaged filter and public alias is included.
+
+Adding a custom filter
+----------------------
+
+A custom filter does not need to be added to the package registry. Create a
+:class:`jaxsedfit.FilterCurve`, place it in a :class:`jaxsedfit.FilterSet`, and
+use exactly the same name in :class:`jaxsedfit.PhotometryData`:
+
+.. code-block:: python
+
+   import numpy as np
+   from jaxsedfit import FilterCurve, FilterSet, PhotometryData
+   from jaxsedfit.filters import load_filter_curves
+
+   wave_angstrom = np.array([4000.0, 4500.0, 5000.0, 5500.0, 6000.0])
+   response = np.array([0.0, 0.35, 1.0, 0.40, 0.0])
+
+   my_filter = FilterCurve(
+       name="my_camera.r",
+       wave=wave_angstrom,
+       transmission=response,
+   )
+
+   # Built-in and custom curves can be used together.
+   cfg.filters = FilterSet(
+       curves=[
+           *load_filter_curves(["galex.NUV", "sloan.sdss.g"]),
+           my_filter,
+       ]
+   )
+   cfg.photometry = PhotometryData(
+       filter_names=["galex.NUV", "sloan.sdss.g", "my_camera.r"],
+       fluxes=[0.12, 0.31, 0.44],       # mJy
+       errors=[0.02, 0.03, 0.04],      # mJy
+   )
+
+Custom wavelengths must be observed-frame Angstrom values. The wavelength and
+response arrays must be one-dimensional, have the same length, and contain at
+least three finite, unique wavelength samples. JAXSEDFit sorts the samples,
+clips negative responses to zero, sets the first and last response values to
+zero, and calculates the pivot wavelength automatically. You can provide
+``effective_wavelength`` explicitly, but normally it should be left as
+``None`` so it is calculated from the normalized curve.
+
+Loading a local response file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For a whitespace-delimited file whose first two columns are wavelength in
+Angstrom and response:
+
+.. code-block:: python
+
+   table = np.loadtxt("my_camera_r.dat")
+   my_filter = FilterCurve(
+       name="my_camera.r",
+       wave=table[:, 0],
+       transmission=table[:, 1],
+   )
+   cfg.filters = FilterSet(curves=[my_filter])
+
+The inline ``transmission`` array is interpreted as the response used for
+synthetic photometry. If the source file contains a photon-counting throughput,
+convert it to the package's energy-response convention first:
+
+.. code-block:: python
+
+   photon_throughput = table[:, 1]
+   energy_response = photon_throughput * table[:, 0]
+   my_filter = FilterCurve(
+       name="my_camera.r",
+       wave=table[:, 0],
+       transmission=energy_response,
+   )
+
+The custom curve name must match its entry in ``photometry.filter_names``.
+Custom curves are fit-local; adding one this way does not modify the packaged
+registry or make the name globally available to
+:func:`jaxsedfit.filters.load_filter_curve`.
+
+Packaged filter registry
+------------------------
+
+.. filter-registry::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,5 +10,6 @@ JAX and NumPyro.
 
    installation
    quickstart
+   filters
    tutorials
    api/index


### PR DESCRIPTION
## Summary
- add a dedicated filter-reference page generated from the packaged registry
- list all 397 canonical filters across 21 telescope and survey families
- group filters by telescope and instrument with pivot wavelengths and aliases
- add instructions for defining inline custom filters and loading local response files
- document wavelength, response, normalization, naming, and photon-counting conventions
- add the page to the main documentation navigation and filters API page

## Validation
- strict Sphinx HTML build with warnings treated as errors
- verified rendered output contains 21 family sections and 397 filter rows