### PR TITLE
Fix custom-component serialization and multiplicative BAL modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ Use `make_custom_line_component(..., line_kind="broad" | "narrow")` for an
 additive line profile. Narrow custom lines receive the same host-aperture
 capture treatment as built-in narrow lines.
 
+Custom components with `metadata["component_type"] == "bal_absorption"`
+return optical depth and are treated as partial-covering multiplicative
+absorption, not additive flux. Their shared transmission attenuates the compact
+AGN disk, additive AGN custom continuum, Fe II, Balmer continuum, and broad
+emission lines consistently in the spectrum, native-filter photometry, and
+rendered SED. Host, torus, and narrow-line emission remain unattenuated. BAL
+diagnostic curves in spectrum plots are negative and show removed flux; the
+logarithmic SED plot shows BAL absorption through the attenuated AGN and total
+curves.
+
+> **BAL posterior compatibility warning:** posterior bundles produced before
+> the multiplicative joint-BAL correction encoded BAL optical depth as positive
+> additive flux and are scientifically invalid, even though they remain
+> loadable. They must be refitted. This includes all `aug31_def_bal` bundles.
+
 Spectroscopy is enabled by supplying one or more `SpectroscopyData` objects;
 there is no separate backend or enabled switch. Photometry is optional, so a
 spectrum-only fit can be configured directly:

--- a/src/jaxsedfit/config.py
+++ b/src/jaxsedfit/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence as SequenceABC
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, Mapping, Sequence
 
 import numpy as np
@@ -1220,7 +1220,10 @@ def serialize_config(value: Any) -> Any:
     ):
         return serialize_config(value.to_state())
     if is_dataclass(value):
-        return {k: serialize_config(v) for k, v in asdict(value).items()}
+        return {
+            item.name: serialize_config(getattr(value, item.name))
+            for item in fields(value)
+        }
     if isinstance(value, dict):
         return {k: serialize_config(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -2577,7 +2577,22 @@ class JAXSEDFit:
             raise RuntimeError("No spectroscopy data are available to plot.")
         from .spectral_plotting import plot_fig
 
-        pred = self.predict(posterior=posterior)
+        configured_custom_components = tuple(
+            getattr(getattr(self.config, "agn", None), "custom_components", ())
+            or ()
+        )
+        custom_component_return_sites = tuple(
+            site_name
+            for custom_component in configured_custom_components
+            for site_name in (
+                f"spectral_{custom_component.deterministic_site_name}",
+                str(custom_component.deterministic_site_name),
+            )
+        )
+        pred = self.predict(
+            posterior=posterior,
+            extra_return_sites=custom_component_return_sites,
+        )
         index = np.asarray(self.context.spec_spectrum_index, dtype=int)
         selected = (index == int(spectrum_index)) & np.asarray(self.context.spec_mask, dtype=bool)
         if not np.any(selected):
@@ -2788,6 +2803,25 @@ class JAXSEDFit:
             "jaxsedfit_host_dust": obs_sed_component("dust_obs_sed", multiplier=host_capture),
             "jaxsedfit_sed_balmer": obs_sed_component("balmer_obs_sed"),
         }
+        custom_component_sites = {}
+        for custom_component in configured_custom_components:
+            component_name = str(custom_component.output_name)
+            deterministic_name = str(custom_component.deterministic_site_name)
+            site_name = next(
+                (
+                    candidate
+                    for candidate in (
+                        f"spectral_{deterministic_name}",
+                        deterministic_name,
+                    )
+                    if candidate in pred
+                ),
+                None,
+            )
+            if site_name is None:
+                continue
+            custom_components[component_name] = component(site_name)
+            custom_component_sites[component_name] = site_name
         if show_nebular_lines:
             custom_components["jaxsedfit_nebular_lines"] = obs_sed_component("nebular_lines_obs_sed")
         plotter.custom_components = {
@@ -2836,6 +2870,12 @@ class JAXSEDFit:
         }
         if show_nebular_lines:
             custom_draws["jaxsedfit_nebular_lines"] = obs_sed_draws("nebular_lines_obs_sed")
+        custom_draws.update(
+            {
+                component_name: spectrum_draws(site_name)
+                for component_name, site_name in custom_component_sites.items()
+            }
+        )
         for name, draws in custom_draws.items():
             if name in plotter.custom_components:
                 band = band_from_draws(draws)

--- a/src/jaxsedfit/core.py
+++ b/src/jaxsedfit/core.py
@@ -589,13 +589,14 @@ class JAXSEDFit:
         return grahsp_photometric_model(self.context, include_components=False)
 
     def _continuum_init_model(self):
-        """Return the MAP warm start with smooth continuum features but no lines."""
+        """Return the MAP warm start with smooth features but no lines or BAL."""
         return grahsp_photometric_model(
             self.context,
             include_components=False,
             include_sed_agn_features=True,
             include_spectral_features=True,
             include_spectral_lines=False,
+            include_spectral_bal=False,
         )
 
     @staticmethod
@@ -1331,6 +1332,7 @@ class JAXSEDFit:
                     include_sed_agn_features=True,
                     include_spectral_features=True,
                     include_spectral_lines=False,
+                    include_spectral_bal=False,
                 )
 
         svi_result, median = self._run_map_svi(
@@ -1361,6 +1363,7 @@ class JAXSEDFit:
                 include_sed_agn_features=True,
                 include_spectral_features=True,
                 include_spectral_lines=True,
+                include_spectral_bal=True,
             )
         self.samples = {k: np.asarray(v)[None, ...] for k, v in median.items()}
         self.predictive = None
@@ -1375,6 +1378,7 @@ class JAXSEDFit:
         include_sed_agn_features: bool,
         include_spectral_features: bool,
         include_spectral_lines: bool,
+        include_spectral_bal: bool,
     ):
         """Plot and retain one MAP solution using the standard SED figure.
 
@@ -1388,6 +1392,7 @@ class JAXSEDFit:
             include_sed_agn_features=include_sed_agn_features,
             include_spectral_features=include_spectral_features,
             include_spectral_lines=include_spectral_lines,
+            include_spectral_bal=include_spectral_bal,
         )
         return_sites = self._prediction_return_sites("plot")
         pred = Predictive(

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -1689,6 +1689,9 @@ def _project_integrated_local_line_filters(
     redshift,
     luminosity_distance_m,
     igm,
+    *,
+    spectral_state=None,
+    spectral_component_cfg=None,
 ):
     """Project integrated line luminosities through filters on local grids.
 
@@ -1720,6 +1723,22 @@ def _project_integrated_local_line_filters(
     attenuation_curve = _attenuation_curve(rest_line_wave, -1.2, -3.0, 1.2, GRAHSP_BIATTENUATION_BREAK_A)
     attenuation_factor = 10 ** (jnp.asarray(ebv_total, dtype=jnp.float64) * attenuation_curve / -2.5)
     flux_lambda = rest_lumin * attenuation_factor * igm_local / distance_scale
+    if spectral_state is not None and spectral_component_cfg is not None:
+        from .spectroscopy import render_joint_feature_state
+
+        bal_only_cfg = replace(
+            spectral_component_cfg,
+            use_lines=False,
+            use_feii=False,
+            use_balmer_continuum=False,
+            custom_line_components=(),
+        )
+        flux_lambda = flux_lambda * render_joint_feature_state(
+            obs_line_wave,
+            redshift,
+            spectral_state,
+            config=bal_only_cfg,
+        )["bal_transmission"]
     curves = context.packed_filter_curves_jax
 
     def _one_filter(filt_wave, filt_trans, denom, eff_wave):
@@ -1772,7 +1791,19 @@ def _project_local_nebular_line_filters(
     )
 
 
-def _local_integrated_line_obs_sed(context: ModelContext, line_wave, line_lumin, width_kms, ebv_total, redshift, luminosity_distance_m, igm):
+def _local_integrated_line_obs_sed(
+    context: ModelContext,
+    line_wave,
+    line_lumin,
+    width_kms,
+    ebv_total,
+    redshift,
+    luminosity_distance_m,
+    igm,
+    *,
+    spectral_state=None,
+    spectral_component_cfg=None,
+):
     """Return observed-frame local-grid wavelengths and F_lambda for lines.
 
     Parameters
@@ -1803,6 +1834,22 @@ def _local_integrated_line_obs_sed(context: ModelContext, line_wave, line_lumin,
     attenuation_curve = _attenuation_curve(rest_line_wave, -1.2, -3.0, 1.2, GRAHSP_BIATTENUATION_BREAK_A)
     attenuation_factor = 10 ** (jnp.asarray(ebv_total, dtype=jnp.float64) * attenuation_curve / -2.5)
     flux_lambda = rest_lumin * attenuation_factor * igm_local / distance_scale
+    if spectral_state is not None and spectral_component_cfg is not None:
+        from .spectroscopy import render_joint_feature_state
+
+        bal_only_cfg = replace(
+            spectral_component_cfg,
+            use_lines=False,
+            use_feii=False,
+            use_balmer_continuum=False,
+            custom_line_components=(),
+        )
+        flux_lambda = flux_lambda * render_joint_feature_state(
+            obs_line_wave,
+            redshift,
+            spectral_state,
+            config=bal_only_cfg,
+        )["bal_transmission"]
     separator = jnp.full((obs_line_wave.shape[0], 1), jnp.nan, dtype=jnp.float64)
     obs_plot = jnp.concatenate([obs_line_wave, separator], axis=1)
     flux_plot = jnp.concatenate([flux_lambda, separator], axis=1)
@@ -3268,6 +3315,7 @@ def _evaluate_spectral_components(
     fixed_narrow_amp_scale=None,
     feature_amplitude_scale=1.0,
     include_lines=True,
+    bal_continuum_mjy=None,
 ):
     """Evaluate the built-in detailed spectral components.
 
@@ -3296,6 +3344,8 @@ def _evaluate_spectral_components(
     feature_amplitude_scale : object
         Calibration scale defining the observed-spectrum coordinate system for
         sampled line, Fe II, and Balmer amplitudes.
+    bal_continuum_mjy : object, optional
+        Compact AGN disk continuum subject to BAL absorption.
     """
     try:
         from .spectroscopy import (
@@ -3340,6 +3390,7 @@ def _evaluate_spectral_components(
         feii_template_flux=feii_template_flux,
         site_prefix="spectral",
         feature_amplitude_scale=feature_amplitude_scale,
+        bal_continuum_mjy=bal_continuum_mjy,
     )
     result["component_config"] = component_cfg
     return result
@@ -3430,7 +3481,7 @@ def _project_spectral_smooth_state_filters(
             & (feature_wave_rest <= coverage_rest[1])
         ).astype(jnp.float64)
     feii_grid = covered * rendered["feii"]
-    extrapolated_feii_grid = (1.0 - covered) * sed_feii
+    extrapolated_feii_grid = (1.0 - covered) * sed_feii * rendered["bal_transmission"]
 
     def _interpolate_one(wave):
         return (
@@ -3459,7 +3510,14 @@ def _project_fnu_mjy_filter_curves(context: ModelContext, wave_obs, fnu_mjy):
     return conversion * context.filter_effective_wavelength_jax**2 * mean_flambda
 
 
-def _project_spectral_custom_state_filters(context, state, redshift, component_cfg):
+def _project_spectral_custom_state_filters(
+    context,
+    state,
+    redshift,
+    component_cfg,
+    *,
+    bal_continuum_mjy=None,
+):
     """Render sampled custom components on native filter grids and integrate them."""
     from .spectroscopy import render_joint_feature_state
 
@@ -3469,13 +3527,11 @@ def _project_spectral_custom_state_filters(context, state, redshift, component_c
         redshift,
         state,
         config=replace(component_cfg, use_lines=False, use_feii=False, use_balmer_continuum=False),
+        bal_continuum_mjy=bal_continuum_mjy,
     )
     custom = rendered["custom"]
     zero = jnp.zeros_like(curves.wave)
-    continuum = sum(
-        (custom[component.output_name] for component in component_cfg.custom_components),
-        zero,
-    )
+    continuum = rendered["custom_continuum"]
     broad = sum(
         (
             custom[component.output_name]
@@ -3498,7 +3554,13 @@ def _project_spectral_custom_state_filters(context, state, redshift, component_c
     )
 
 
-def _project_spectral_line_state_filters(context: ModelContext, state, redshift, broad_only=None):
+def _project_spectral_line_state_filters(
+    context: ModelContext,
+    state,
+    redshift,
+    broad_only=None,
+    component_cfg=None,
+):
     """Project sampled log-wavelength Gaussians using flux-conserving local grids."""
     amps = jnp.asarray(state.get("line_amp_per_component", jnp.zeros(0)), dtype=jnp.float64)
     n_filters = context.packed_filter_curves_jax.wave.shape[0]
@@ -3515,6 +3577,29 @@ def _project_spectral_line_state_filters(context: ModelContext, state, redshift,
     rest_wave = jnp.exp(mus[:, None] + sigs[:, None] * nodes[None, :])
     obs_line_wave = rest_wave * (1.0 + redshift)
     fnu = amps[:, None] * jnp.exp(-0.5 * nodes[None, :] ** 2)
+    if component_cfg is not None and broad_only is not False:
+        from .spectroscopy import render_joint_feature_state
+
+        bal_only_cfg = replace(
+            component_cfg,
+            use_lines=False,
+            use_feii=False,
+            use_balmer_continuum=False,
+            custom_line_components=(),
+        )
+        bal_transmission = render_joint_feature_state(
+            obs_line_wave,
+            redshift,
+            state,
+            config=bal_only_cfg,
+        )["bal_transmission"]
+        if broad_only is True:
+            fnu = fnu * bal_transmission
+        else:
+            fnu = fnu * (
+                broad_mask[:, None] * bal_transmission
+                + (1.0 - broad_mask[:, None])
+            )
     conversion = 1.0e-10 / 299792458.0 * 1.0e29
     flambda = fnu / jnp.maximum(conversion * obs_line_wave**2, 1.0e-30)
     curves = context.packed_filter_curves_jax
@@ -4490,10 +4575,24 @@ def evaluate_photometric_state(
     spectral_extrapolated_broad_width = jnp.asarray(DEFAULT_BROAD_LINE_WIDTH_KMS, dtype=jnp.float64)
     spectral_extrapolated_narrow_width = jnp.asarray(DEFAULT_NARROW_LINE_WIDTH_KMS, dtype=jnp.float64)
     spectral_photometry_adjustment = jnp.zeros_like(pred_fluxes)
+    spectral_custom_continuum_photometry = jnp.zeros_like(pred_fluxes)
     spectral_line_obs_sed = jnp.zeros_like(obs_wave)
     spectral_feii_obs_sed = jnp.zeros_like(obs_wave)
     spectral_balmer_obs_sed = jnp.zeros_like(obs_wave)
     spectral_custom_continuum_obs_sed = jnp.zeros_like(obs_wave)
+    spectral_bal_decrement_obs_sed = jnp.zeros_like(obs_wave)
+    active_bal_component_config = None
+    disk_obs_for_bal = (
+        _redshift_to_obs(
+            rest_wave,
+            disk_att_rest * igm,
+            obs_wave,
+            redshift,
+            luminosity_distance_m,
+        )
+        if spectroscopy_enabled and include_spectral_features
+        else jnp.zeros_like(obs_wave)
+    )
     if spectroscopy_enabled:
         use_spec_resolution_continuum = bool(
             context.spec_host_basis_jax is not None
@@ -4574,20 +4673,36 @@ def evaluate_photometric_state(
             spec_torus_model_fluxes = _flambda_to_mjy(spec_wave_obs, spec_torus_lambda)
             spec_model_fluxes = spec_host_model_fluxes + spec_disk_model_fluxes + spec_torus_model_fluxes
         else:
-            spec_source_obs = host_obs + _redshift_to_obs(
+            disk_obs_for_spectrum = _redshift_to_obs(
                 rest_wave,
-                (disk_rest + torus_rest) * igm,
+                disk_att_rest * igm,
                 obs_wave,
                 redshift,
                 luminosity_distance_m,
             )
+            torus_obs_for_spectrum = _redshift_to_obs(
+                rest_wave,
+                torus_att_rest * igm,
+                obs_wave,
+                redshift,
+                luminosity_distance_m,
+            )
+            spec_source_obs = host_obs + disk_obs_for_spectrum + torus_obs_for_spectrum
             spec_model_lambda = jnp.interp(spec_wave_obs, obs_wave, spec_source_obs, left=0.0, right=0.0)
             spec_host_lambda = jnp.interp(spec_wave_obs, obs_wave, host_obs, left=0.0, right=0.0)
+            spec_disk_lambda = jnp.interp(
+                spec_wave_obs, obs_wave, disk_obs_for_spectrum, left=0.0, right=0.0
+            )
+            spec_torus_lambda = jnp.interp(
+                spec_wave_obs, obs_wave, torus_obs_for_spectrum, left=0.0, right=0.0
+            )
             if host_capture_enabled:
                 spec_capture_at_pixel = spec_host_capture_fraction_by_spectrum[spec_spectrum_index]
                 spec_model_lambda = spec_model_lambda - spec_host_lambda + spec_capture_at_pixel * spec_host_lambda
                 spec_host_lambda = spec_capture_at_pixel * spec_host_lambda
             spec_host_model_fluxes = _flambda_to_mjy(spec_wave_obs, spec_host_lambda)
+            spec_disk_model_fluxes = _flambda_to_mjy(spec_wave_obs, spec_disk_lambda)
+            spec_torus_model_fluxes = _flambda_to_mjy(spec_wave_obs, spec_torus_lambda)
             spec_model_fluxes = _flambda_to_mjy(spec_wave_obs, spec_model_lambda)
         spec_continuum_model_fluxes = spec_model_fluxes
         fit_spectrum_scale = (
@@ -4646,6 +4761,7 @@ def evaluate_photometric_state(
                 line_coverage_rest=spectral_line_coverage_rest,
                 feature_amplitude_scale=feature_amplitude_scale,
                 include_lines=include_spectral_lines,
+                bal_continuum_mjy=spec_disk_model_fluxes,
             )
             spectral_cfg = cfg.agn
             if host_capture_enabled and bool(
@@ -4682,6 +4798,7 @@ def evaluate_photometric_state(
                 redshift,
                 spectral_state,
                 config=spectral_components["component_config"],
+                bal_continuum_mjy=_flambda_to_mjy(obs_wave, disk_obs_for_bal),
             )
             spectral_sed_lines_mjy = spectral_sed_rendered["lines"]
             sed_mjy_per_flambda = jnp.maximum(
@@ -4691,6 +4808,9 @@ def evaluate_photometric_state(
             spectral_line_obs_sed = spectral_sed_lines_mjy / sed_mjy_per_flambda
             spectral_custom_continuum_obs_sed = (
                 spectral_sed_rendered["custom_continuum"] / sed_mjy_per_flambda
+            )
+            spectral_bal_decrement_obs_sed = (
+                spectral_sed_rendered["bal_decrement"] / sed_mjy_per_flambda
             )
             # Fe II and Balmer broadening are comparatively expensive FFTs.
             # Render them only for component predictions used by plotting, not
@@ -4708,18 +4828,27 @@ def evaluate_photometric_state(
                 )
                 spectral_feii_obs_sed = spectral_sed_smooth_mjy["feii"] / sed_mjy_per_flambda
                 spectral_balmer_obs_sed = spectral_sed_smooth_mjy["balmer"] / sed_mjy_per_flambda
+            component_config = spectral_components["component_config"]
+            if any(
+                str(getattr(component, "metadata", {}).get("component_type", ""))
+                == "bal_absorption"
+                for component in getattr(component_config, "custom_components", ())
+            ):
+                active_bal_component_config = component_config
             spectral_broad_photometry = _project_spectral_line_state_filters(
-                context, spectral_state, redshift, broad_only=True
+                context,
+                spectral_state,
+                redshift,
+                broad_only=True,
+                component_cfg=active_bal_component_config,
             )
             spectral_narrow_photometry_total = _project_spectral_line_state_filters(
                 context, spectral_state, redshift, broad_only=False
             )
             spectral_narrow_photometry = spectral_narrow_photometry_total * host_capture_fraction
             spectral_line_photometry = spectral_broad_photometry + spectral_narrow_photometry
-            spectral_custom_continuum_photometry = jnp.zeros_like(pred_fluxes)
             spectral_custom_broad_photometry = jnp.zeros_like(pred_fluxes)
             spectral_custom_narrow_photometry_total = jnp.zeros_like(pred_fluxes)
-            component_config = spectral_components["component_config"]
             if (
                 getattr(component_config, "custom_components", ())
                 or getattr(component_config, "custom_line_components", ())
@@ -4733,6 +4862,18 @@ def evaluate_photometric_state(
                     spectral_state,
                     redshift,
                     component_config,
+                    bal_continuum_mjy=_flambda_to_mjy(
+                        context.packed_filter_curves_jax.wave,
+                        jax.vmap(
+                            lambda wave: jnp.interp(
+                                wave,
+                                obs_wave,
+                                disk_obs_for_bal,
+                                left=0.0,
+                                right=0.0,
+                            )
+                        )(context.packed_filter_curves_jax.wave),
+                    ),
                 )
             spectral_custom_narrow_photometry = (
                 spectral_custom_narrow_photometry_total * host_capture_fraction
@@ -4799,6 +4940,8 @@ def evaluate_photometric_state(
                     redshift,
                     luminosity_distance_m,
                     igm,
+                    spectral_state=spectral_state,
+                    spectral_component_cfg=active_bal_component_config,
                 )
                 spectral_extrapolated_narrow_total = _project_integrated_local_line_filters(
                     context,
@@ -4964,6 +5107,8 @@ def evaluate_photometric_state(
             redshift,
             luminosity_distance_m,
             igm,
+            spectral_state=spectral_state if active_bal_component_config is not None else None,
+            spectral_component_cfg=active_bal_component_config,
         )
         agn_narrow_local_wave, agn_narrow_local_obs = _local_integrated_line_obs_sed(
             context,
@@ -5162,10 +5307,13 @@ def evaluate_photometric_state(
     numpyro.deterministic("spectral_balmer_photometry", spectral_balmer_photometry)
     numpyro.deterministic("spectral_extrapolated_broad_photometry", spectral_extrapolated_broad_photometry)
     numpyro.deterministic("spectral_extrapolated_narrow_photometry", spectral_extrapolated_narrow_photometry)
+    numpyro.deterministic("spectral_custom_continuum_photometry", spectral_custom_continuum_photometry)
+    numpyro.deterministic("spectral_photometry_adjustment", spectral_photometry_adjustment)
     numpyro.deterministic("spectral_line_obs_sed", spectral_line_obs_sed)
     numpyro.deterministic("spectral_feii_obs_sed", spectral_feii_obs_sed)
     numpyro.deterministic("spectral_balmer_obs_sed", spectral_balmer_obs_sed)
     numpyro.deterministic("spectral_custom_continuum_obs_sed", spectral_custom_continuum_obs_sed)
+    numpyro.deterministic("spectral_bal_decrement_obs_sed", spectral_bal_decrement_obs_sed)
     numpyro.deterministic(SpectralSites.CONTINUUM_FLUX, spec_continuum_model_fluxes)
     numpyro.deterministic(SpectralSites.HOST_FLUX, spec_host_model_fluxes)
     numpyro.deterministic(SpectralSites.DISK_FLUX, spec_disk_model_fluxes)

--- a/src/jaxsedfit/model.py
+++ b/src/jaxsedfit/model.py
@@ -3316,6 +3316,7 @@ def _evaluate_spectral_components(
     feature_amplitude_scale=1.0,
     include_lines=True,
     bal_continuum_mjy=None,
+    include_bal_components=True,
 ):
     """Evaluate the built-in detailed spectral components.
 
@@ -3346,8 +3347,12 @@ def _evaluate_spectral_components(
         sampled line, Fe II, and Balmer amplitudes.
     bal_continuum_mjy : object, optional
         Compact AGN disk continuum subject to BAL absorption.
+    include_bal_components : bool, optional
+        Whether BAL absorption custom components are active. Other custom
+        continuum and line components are unaffected.
     """
     try:
+        from .spectral_custom_components import is_bal_absorption_component
         from .spectroscopy import (
             SpectralComponentConfig,
             evaluate_joint_spectral_components,
@@ -3358,6 +3363,17 @@ def _evaluate_spectral_components(
         ) from exc
 
     spectral_cfg = cfg.agn
+
+    def _active_components(components):
+        components = tuple(components or ())
+        if include_bal_components:
+            return components
+        return tuple(
+            component
+            for component in components
+            if not is_bal_absorption_component(component)
+        )
+
     component_cfg = SpectralComponentConfig(
         use_lines=bool(spectral_cfg.fit_lines and include_lines),
         tied_lines=bool(spectral_cfg.tied_lines),
@@ -3377,9 +3393,9 @@ def _evaluate_spectral_components(
         broadening_convolution=spectral_cfg.broadening_convolution,
         fixed_narrow_fwhm_kms=fixed_narrow_fwhm_kms,
         fixed_narrow_amp_scale=fixed_narrow_amp_scale,
-        custom_components=spectral_cfg.custom_components or (),
-        custom_line_components=spectral_cfg.custom_line_components or (),
-        components=getattr(spectral_cfg, "components", ()) or (),
+        custom_components=_active_components(spectral_cfg.custom_components),
+        custom_line_components=_active_components(spectral_cfg.custom_line_components),
+        components=_active_components(getattr(spectral_cfg, "components", ())),
     )
     result = evaluate_joint_spectral_components(
         wave_obs,
@@ -3680,6 +3696,7 @@ def evaluate_photometric_state(
     return_state: bool = True,
     force_component_fluxes: bool = False,
     include_spectral_lines: bool = True,
+    include_spectral_bal: bool = True,
 ):
     """Evaluate one jaxsedfit photometric model state inside a NumPyro trace.
 
@@ -3697,6 +3714,9 @@ def evaluate_photometric_state(
         Whether detailed broad and narrow emission lines are active. Smooth
         spectral features such as Fe II and Balmer continuum remain controlled
         by ``include_spectral_features``.
+    include_spectral_bal : bool
+        Whether BAL absorption custom components are active. Ordinary custom
+        components remain controlled by ``include_spectral_features``.
     add_likelihood : object
         add_likelihood value.
     return_state : object
@@ -4762,6 +4782,7 @@ def evaluate_photometric_state(
                 feature_amplitude_scale=feature_amplitude_scale,
                 include_lines=include_spectral_lines,
                 bal_continuum_mjy=spec_disk_model_fluxes,
+                include_bal_components=include_spectral_bal,
             )
             spectral_cfg = cfg.agn
             if host_capture_enabled and bool(
@@ -5522,6 +5543,7 @@ def grahsp_photometric_model(
     include_spectral_features: bool = True,
     include_spectral_lines: bool = True,
     force_component_fluxes: bool = False,
+    include_spectral_bal: bool = True,
 ):
     """NumPyro model for one jaxsedfit photometric fit or predictive expansion.
 
@@ -5540,6 +5562,8 @@ def grahsp_photometric_model(
     force_component_fluxes : object
         Compute component band fluxes even when the likelihood does not need
         them. Used by lightweight posterior prediction products.
+    include_spectral_bal : object
+        include_spectral_bal value.
     """
     return evaluate_photometric_state(
         context,
@@ -5547,6 +5571,7 @@ def grahsp_photometric_model(
         include_sed_agn_features=include_sed_agn_features,
         include_spectral_features=include_spectral_features,
         include_spectral_lines=include_spectral_lines,
+        include_spectral_bal=include_spectral_bal,
         force_component_fluxes=force_component_fluxes,
         add_likelihood=True,
         return_state=False,
@@ -5559,6 +5584,7 @@ def sed_numpyro_model(
     include_sed_agn_features: bool = True,
     include_spectral_features: bool = True,
     include_spectral_lines: bool = True,
+    include_spectral_bal: bool = True,
 ):
     """NumPyro SED model for one configured ``jaxsedfit`` target.
 
@@ -5578,6 +5604,8 @@ def sed_numpyro_model(
         include_spectral_features value.
     include_spectral_lines : object
         include_spectral_lines value.
+    include_spectral_bal : object
+        include_spectral_bal value.
     """
     return grahsp_photometric_model(
         context,
@@ -5585,6 +5613,7 @@ def sed_numpyro_model(
         include_sed_agn_features=include_sed_agn_features,
         include_spectral_features=include_spectral_features,
         include_spectral_lines=include_spectral_lines,
+        include_spectral_bal=include_spectral_bal,
     )
 
 
@@ -5597,6 +5626,7 @@ def evaluate_sed_model(
     return_state: bool = True,
     force_component_fluxes: bool = False,
     include_spectral_lines: bool = True,
+    include_spectral_bal: bool = True,
 ):
     """Evaluate the SED model state for a configured target.
 
@@ -5616,6 +5646,8 @@ def evaluate_sed_model(
         include_spectral_features value.
     include_spectral_lines : object
         include_spectral_lines value.
+    include_spectral_bal : object
+        include_spectral_bal value.
     add_likelihood : object
         add_likelihood value.
     return_state : object
@@ -5629,6 +5661,7 @@ def evaluate_sed_model(
         include_sed_agn_features=include_sed_agn_features,
         include_spectral_features=include_spectral_features,
         include_spectral_lines=include_spectral_lines,
+        include_spectral_bal=include_spectral_bal,
         add_likelihood=add_likelihood,
         return_state=return_state,
         force_component_fluxes=force_component_fluxes,

--- a/src/jaxsedfit/plotting.py
+++ b/src/jaxsedfit/plotting.py
@@ -573,6 +573,56 @@ def _median_effective_variance(fitter, pred: dict[str, Any]) -> np.ndarray:
     return np.nan_to_num(obs_variance + sys_variance + var_variance, nan=1.0e30, posinf=1.0e30, neginf=1.0e30)
 
 
+def _place_overlapping_band_annotations(
+    fig,
+    annotations,
+    *,
+    base_offset_points: float = 8.0,
+    horizontal_padding_pixels: float = 2.0,
+):
+    """Place colliding labels above upper points and below lower points."""
+    if not annotations:
+        return
+
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    footprints = sorted(
+        (
+            (annotation.get_window_extent(renderer), annotation)
+            for annotation in annotations
+        ),
+        key=lambda item: item[0].x0,
+    )
+    groups = []
+    current_group = []
+    current_right_edge = -np.inf
+    for bbox, annotation in footprints:
+        if current_group and bbox.x0 >= current_right_edge + horizontal_padding_pixels:
+            groups.append(current_group)
+            current_group = []
+            current_right_edge = -np.inf
+        current_group.append(annotation)
+        current_right_edge = max(current_right_edge, float(bbox.x1))
+    if current_group:
+        groups.append(current_group)
+
+    for group in groups:
+        ordered_by_height = sorted(
+            group,
+            key=lambda annotation: annotation.axes.transData.transform(
+                annotation.xy
+            )[1],
+        )
+        lower_count = len(ordered_by_height) // 2
+        for index, annotation in enumerate(ordered_by_height):
+            if len(group) > 1 and index < lower_count:
+                annotation.set_position((0, -base_offset_points))
+                annotation.set_verticalalignment("top")
+            else:
+                annotation.set_position((0, base_offset_points))
+                annotation.set_verticalalignment("bottom")
+
+
 def plot_fit_sed(
     fitter,
     output_path: str | Path | None = None,
@@ -877,9 +927,31 @@ def plot_fit_sed(
             zorder=7,
         )
         ax_sed.scatter(phot_wave, model_flux, color="#111111", marker="s", s=28, label="Model photometry", zorder=6)
+        band_annotations = []
         if annotate_band_names:
-            for x, y, label in zip(phot_wave, obs_flux, labels):
-                ax_sed.annotate(label, (x, y), xytext=(4, 5), textcoords="offset points", fontsize=8)
+            for index, (x, label) in enumerate(zip(phot_wave, labels)):
+                band_annotations.append(
+                    ax_sed.annotate(
+                        label,
+                        (x, obs_flux[index]),
+                        xytext=(0, 8),
+                        textcoords="offset points",
+                        fontsize=7.5,
+                        ha="center",
+                        va="bottom",
+                        rotation=90,
+                        rotation_mode="default",
+                        annotation_clip=False,
+                        zorder=20,
+                        bbox={
+                            "boxstyle": "round,pad=0.16",
+                            "facecolor": "#fffdf8",
+                            "edgecolor": "#d8d4ca",
+                            "linewidth": 0.45,
+                            "alpha": 0.62,
+                        },
+                    )
+                )
 
         eff_variance = _median_effective_variance(fitter, pred)
         eff_sigma = np.sqrt(np.clip(eff_variance, 1e-30, 1.0e60))
@@ -944,6 +1016,7 @@ def plot_fit_sed(
         ax_resid.set_xlim(x_min, x_max)
 
         fig.tight_layout()
+        _place_overlapping_band_annotations(fig, band_annotations)
         if output_path is not None:
             output_path = Path(output_path)
             output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/jaxsedfit/spectral_components.py
+++ b/src/jaxsedfit/spectral_components.py
@@ -28,6 +28,9 @@ from .spectral_reparameterization import (
 from .spectral_custom_components import (
     CustomComponentSpec,
     CustomLineComponentSpec,
+    bal_component_transmission,
+    custom_component_param_site,
+    is_bal_absorption_component,
     normalize_custom_components,
     normalize_custom_line_components,
     split_spectral_components,
@@ -131,6 +134,127 @@ def _render_custom_components(wave_obs, wave_rest, state, cfg):
             dtype=jnp.float64,
         )
     return models
+
+
+def _apply_bal_absorption(
+    wave,
+    raw_custom,
+    state,
+    cfg,
+    *,
+    line_broad,
+    line_narrow,
+    feii,
+    balmer,
+    bal_continuum_mjy=None,
+):
+    """Apply partial-covering BAL transmission to compact AGN components.
+
+    BAL component evaluators return optical depth, not flux.  This helper is
+    the single conversion point from those positive optical-depth profiles to
+    multiplicative transmission and negative diagnostic flux decrements.
+    Host, torus, and narrow-line light are intentionally absent from the BAL
+    reference and therefore remain unattenuated.
+    """
+    zero = jnp.zeros_like(wave)
+    one = jnp.ones_like(wave)
+    bal_components = tuple(
+        component
+        for component in cfg.custom_components
+        if is_bal_absorption_component(component)
+    )
+    additive_components = tuple(
+        component
+        for component in cfg.custom_components
+        if not is_bal_absorption_component(component)
+    )
+
+    additive_continuum = sum(
+        (raw_custom[component.output_name] for component in additive_components),
+        zero,
+    )
+    custom_line_broad = sum(
+        (
+            raw_custom[component.output_name]
+            for component in cfg.custom_line_components
+            if component.line_kind == "broad"
+        ),
+        zero,
+    )
+    custom_line_narrow = sum(
+        (
+            raw_custom[component.output_name]
+            for component in cfg.custom_line_components
+            if component.line_kind == "narrow"
+        ),
+        zero,
+    )
+    line_broad_unattenuated = line_broad + custom_line_broad
+    line_narrow_unattenuated = line_narrow + custom_line_narrow
+
+    transmission = one
+    component_transmissions = {}
+    for component in bal_components:
+        params = state.get(f"custom:{component.prefix}", {})
+        component_transmission = bal_component_transmission(
+            raw_custom[component.output_name],
+            params,
+        )
+        component_transmissions[component.output_name] = component_transmission
+        transmission = transmission * component_transmission
+    transmission = jnp.clip(transmission, 1.0e-6, 1.0)
+
+    bal_continuum = (
+        zero
+        if bal_continuum_mjy is None
+        else jnp.asarray(bal_continuum_mjy, dtype=jnp.float64)
+    )
+    bal_reference = (
+        bal_continuum
+        + additive_continuum
+        + line_broad_unattenuated
+        + feii
+        + balmer
+    )
+    bal_decrement = bal_reference * (transmission - 1.0)
+
+    custom_models = {}
+    for component in additive_components:
+        custom_models[component.output_name] = (
+            raw_custom[component.output_name] * transmission
+        )
+    for component in cfg.custom_line_components:
+        component_model = raw_custom[component.output_name]
+        if component.line_kind == "broad":
+            component_model = component_model * transmission
+        custom_models[component.output_name] = component_model
+    running_transmission = one
+    for component in bal_components:
+        component_transmission = component_transmissions[component.output_name]
+        # Attribute only the additional decrement introduced at this stage.
+        # These transition diagnostics therefore sum exactly to the combined
+        # product decrement, even where BAL troughs overlap.
+        custom_models[component.output_name] = (
+            bal_reference
+            * running_transmission
+            * (component_transmission - 1.0)
+        )
+        running_transmission = running_transmission * component_transmission
+
+    return {
+        "line_broad": line_broad_unattenuated * transmission,
+        "line_narrow": line_narrow_unattenuated,
+        "feii": feii * transmission,
+        "balmer": balmer * transmission,
+        "custom_continuum": (
+            additive_continuum * transmission
+            + bal_continuum * (transmission - 1.0)
+        ),
+        "custom": custom_models,
+        "bal_transmission": transmission,
+        "bal_decrement": bal_decrement,
+        "bal_component_transmissions": component_transmissions,
+    }
 
 
 def _as_config(config: SpectralComponentConfig | None) -> SpectralComponentConfig:
@@ -400,6 +524,7 @@ def render_joint_feature_state(
     config: SpectralComponentConfig | None = None,
     feii_template_wave_rest=None,
     feii_template_flux=None,
+    bal_continuum_mjy=None,
 ):
     """Render an already sampled joint-feature state on any observed grid.
 
@@ -453,28 +578,30 @@ def render_joint_feature_state(
         )
         balmer = _flambda_shape_to_fnu_mjy_shape(wave_rest, balmer_flambda, cfg.balmer_fnu_pivot_rest)
 
-    custom = _render_custom_components(wave_obs, wave_rest, state, cfg)
-    custom_continuum = sum(
-        (custom[component.output_name] for component in cfg.custom_components),
-        jnp.zeros_like(wave_obs),
-    )
-    custom_line_broad = sum(
-        (custom[component.output_name] for component in cfg.custom_line_components if component.line_kind == "broad"),
-        jnp.zeros_like(wave_obs),
-    )
-    custom_line_narrow = sum(
-        (custom[component.output_name] for component in cfg.custom_line_components if component.line_kind == "narrow"),
-        jnp.zeros_like(wave_obs),
+    raw_custom = _render_custom_components(wave_obs, wave_rest, state, cfg)
+    absorbed = _apply_bal_absorption(
+        wave_obs,
+        raw_custom,
+        state,
+        cfg,
+        line_broad=line_broad,
+        line_narrow=line_narrow,
+        feii=feii,
+        balmer=balmer,
+        bal_continuum_mjy=bal_continuum_mjy,
     )
 
     return {
-        "lines": line_broad + line_narrow + custom_line_broad + custom_line_narrow,
-        "line_broad": line_broad + custom_line_broad,
-        "line_narrow": line_narrow + custom_line_narrow,
-        "feii": feii,
-        "balmer": balmer,
-        "custom_continuum": custom_continuum,
-        "custom": custom,
+        "lines": absorbed["line_broad"] + absorbed["line_narrow"],
+        "line_broad": absorbed["line_broad"],
+        "line_narrow": absorbed["line_narrow"],
+        "feii": absorbed["feii"],
+        "balmer": absorbed["balmer"],
+        "custom_continuum": absorbed["custom_continuum"],
+        "custom": absorbed["custom"],
+        "bal_transmission": absorbed["bal_transmission"],
+        "bal_decrement": absorbed["bal_decrement"],
+        "bal_component_transmissions": absorbed["bal_component_transmissions"],
     }
 
 
@@ -488,6 +615,7 @@ def evaluate_joint_spectral_components(
     feii_template_flux=None,
     site_prefix: str = "spectral",
     feature_amplitude_scale=1.0,
+    bal_continuum_mjy=None,
 ):
     """Evaluate shared spectral components around an external continuum.
 
@@ -505,6 +633,9 @@ def evaluate_joint_spectral_components(
         Fe II, and Balmer amplitudes are sampled in that observed coordinate
         system and divided by this value before being added to the intrinsic
         continuum. The default of one preserves standalone behavior.
+    bal_continuum_mjy
+        Compact AGN continuum subject to BAL absorption. If omitted, the full
+        supplied continuum is used for backward compatibility.
     feii_template_wave_rest, feii_template_flux
         Rest-frame Fe II template sampled as an f_lambda-shaped relative
         spectrum. The evaluated Fe II component is converted to f_nu shape
@@ -537,6 +668,11 @@ def evaluate_joint_spectral_components(
         calibration = _positive_multiplicative_calibration(tilt * jnp.log(wave_obs / pivot))
 
     continuum_model = calibration * continuum_mjy
+    bal_continuum_model = calibration * (
+        continuum_mjy
+        if bal_continuum_mjy is None
+        else jnp.asarray(bal_continuum_mjy, dtype=jnp.float64)
+    )
     line_model = jnp.zeros_like(wave_obs)
     line_broad_model = jnp.zeros_like(wave_obs)
     line_narrow_model = jnp.zeros_like(wave_obs)
@@ -618,38 +754,48 @@ def evaluate_joint_spectral_components(
         )
 
     feature_state = dict(line_diagnostics)
-    custom_models = {}
+    raw_custom_models = {}
+    sampled_custom_params = {}
     for component in (*cfg.custom_components, *cfg.custom_line_components):
-        params = {
-            name: numpyro.sample(f"{site_prefix}_{component.site_name(name)}", prior)
-            for name, prior in component.parameter_priors.items()
-        }
+        params = {}
+        for name, prior in component.parameter_priors.items():
+            parameter_site = custom_component_param_site(component, name)
+            full_site = f"{site_prefix}_{parameter_site}"
+            if full_site not in sampled_custom_params:
+                sampled_custom_params[full_site] = numpyro.sample(full_site, prior)
+            params[name] = sampled_custom_params[full_site]
         feature_state[f"custom:{component.prefix}"] = params
         model = jnp.asarray(
             component.evaluate(_custom_wave(wave_obs, wave_rest, component), params, component.metadata),
             dtype=jnp.float64,
         )
-        custom_models[component.output_name] = model
-        numpyro.deterministic(f"{site_prefix}_{component.deterministic_site_name}", model)
+        raw_custom_models[component.output_name] = model
 
-    custom_continuum_model = sum(
-        (custom_models[component.output_name] for component in cfg.custom_components),
-        jnp.zeros_like(wave_obs),
+    absorbed = _apply_bal_absorption(
+        wave_obs,
+        raw_custom_models,
+        feature_state,
+        cfg,
+        line_broad=line_broad_model,
+        line_narrow=line_narrow_model,
+        feii=feii_model,
+        balmer=balmer_model,
+        bal_continuum_mjy=bal_continuum_model,
     )
-    custom_line_broad_model = sum(
-        (custom_models[component.output_name] for component in cfg.custom_line_components if component.line_kind == "broad"),
-        jnp.zeros_like(wave_obs),
-    )
-    custom_line_narrow_model = sum(
-        (custom_models[component.output_name] for component in cfg.custom_line_components if component.line_kind == "narrow"),
-        jnp.zeros_like(wave_obs),
-    )
-    line_broad_model = line_broad_model + custom_line_broad_model
-    line_narrow_model = line_narrow_model + custom_line_narrow_model
-    line_model = line_model + custom_line_broad_model + custom_line_narrow_model
-
+    custom_models = absorbed["custom"]
+    custom_continuum_model = absorbed["custom_continuum"]
+    line_broad_model = absorbed["line_broad"]
+    line_narrow_model = absorbed["line_narrow"]
+    line_model = line_broad_model + line_narrow_model
+    feii_model = absorbed["feii"]
+    balmer_model = absorbed["balmer"]
     continuum_model = continuum_model + custom_continuum_model
     total = continuum_model + line_model + feii_model + balmer_model
+    for component in (*cfg.custom_components, *cfg.custom_line_components):
+        numpyro.deterministic(
+            f"{site_prefix}_{component.deterministic_site_name}",
+            custom_models[component.output_name],
+        )
     numpyro.deterministic(f"{site_prefix}_continuum_model", continuum_model)
     numpyro.deterministic(f"{site_prefix}_line_model", line_model)
     numpyro.deterministic(f"{site_prefix}_line_model_broad", line_broad_model)
@@ -658,6 +804,8 @@ def evaluate_joint_spectral_components(
         numpyro.deterministic(f"{site_prefix}_{name}", value)
     numpyro.deterministic(f"{site_prefix}_feii_model", feii_model)
     numpyro.deterministic(f"{site_prefix}_balmer_model", balmer_model)
+    numpyro.deterministic(f"{site_prefix}_bal_transmission", absorbed["bal_transmission"])
+    numpyro.deterministic(f"{site_prefix}_bal_decrement", absorbed["bal_decrement"])
     numpyro.deterministic(f"{site_prefix}_total_model", total)
     if cfg.use_feii and feii_template_wave_rest is not None and feii_template_flux is not None:
         feature_state.update(feii_norm=feii_norm, feii_fwhm=feii_fwhm, feii_shift=feii_shift)
@@ -673,5 +821,8 @@ def evaluate_joint_spectral_components(
         "balmer": balmer_model,
         "custom_continuum": custom_continuum_model,
         "custom": custom_models,
+        "bal_transmission": absorbed["bal_transmission"],
+        "bal_decrement": absorbed["bal_decrement"],
+        "bal_component_transmissions": absorbed["bal_component_transmissions"],
         "state": feature_state,
     }

--- a/src/jaxsedfit/spectral_custom_components.py
+++ b/src/jaxsedfit/spectral_custom_components.py
@@ -107,6 +107,24 @@ def custom_component_param_site(comp: Any, param_name: str) -> str:
     return comp.site_name(param_name)
 
 
+def is_bal_absorption_component(comp: Any) -> bool:
+    """Return whether a custom continuum component encodes BAL optical depth."""
+    return str(getattr(comp, "metadata", {}).get("component_type", "")) == "bal_absorption"
+
+
+def bal_covering_fraction(params: Mapping[str, Any]):
+    """Return a numerically safe partial-covering fraction."""
+    return jnp.clip(jnp.asarray(params.get("covering", 1.0)), 0.0, 0.999)
+
+
+def bal_component_transmission(tau_profile, params: Mapping[str, Any]):
+    """Convert a non-negative BAL optical-depth profile into transmission."""
+    tau_profile = jnp.maximum(jnp.asarray(tau_profile), 0.0)
+    covering = bal_covering_fraction(params)
+    transmission = 1.0 - covering * (1.0 - jnp.exp(-tau_profile))
+    return jnp.clip(transmission, 1.0e-6, 1.0)
+
+
 def _normalize_parameter_prior(value: Any) -> dist.Distribution:
     """Normalize a custom-component prior to a NumPyro distribution.
 

--- a/src/jaxsedfit/spectral_model.py
+++ b/src/jaxsedfit/spectral_model.py
@@ -23,7 +23,9 @@ from .host import (
 from .spectral_custom_components import (
     CustomComponentSpec,
     CustomLineComponentSpec,
+    bal_component_transmission,
     custom_component_param_site,
+    is_bal_absorption_component,
     normalize_custom_components,
     normalize_custom_line_components,
 )
@@ -518,18 +520,7 @@ def _is_multiplicative_bal_component(comp):
     comp : object
         comp value.
     """
-    return str(getattr(comp, "metadata", {}).get("component_type", "")) == "bal_absorption"
-
-
-def _bal_covering_fraction(params):
-    """Return a bounded BAL covering fraction.
-
-    Parameters
-    ----------
-    params : object
-        params value.
-    """
-    return jnp.clip(jnp.asarray(params.get("covering", 1.0)), 0.0, 0.999)
+    return is_bal_absorption_component(comp)
 
 
 def _smc_like_reddening_jax(wave, ebv, uv_ref=2500.0, alpha=1.2):
@@ -4289,9 +4280,7 @@ def qso_fsps_joint_model(wave, flux, err, conti_priors, tied_line_meta, fsps_gri
                 for param_name in comp.parameter_priors
             }
             tau_profile = jnp.asarray(comp.evaluate(wave, bal_params, comp.metadata), dtype=jnp.float64)
-            covering = _bal_covering_fraction(bal_params)
-            component_transmission = 1.0 - covering * (1.0 - jnp.exp(-tau_profile))
-            component_transmission = jnp.clip(component_transmission, 1.0e-6, 1.0)
+            component_transmission = bal_component_transmission(tau_profile, bal_params)
             custom_models[comp.output_name] = bal_reference * (component_transmission - 1.0)
             bal_transmission = bal_transmission * component_transmission
 

--- a/src/jaxsedfit/spectral_plotting.py
+++ b/src/jaxsedfit/spectral_plotting.py
@@ -20,6 +20,18 @@ from .plotting import _STANDARDIZED_RESIDUAL_LABEL, _standardized_residuals
 
 _SDSS_PSF_BANDS = ("u", "g", "r", "i", "z")
 _SDSS_FILTER_CACHE = None
+_CUSTOM_COMPONENT_COLORS = (
+    "darkorange",
+    "crimson",
+    "slateblue",
+    "seagreen",
+    "saddlebrown",
+    "deeppink",
+)
+_NAMED_COMPONENT_COLORS = {
+    "broad_lines": "red",
+    "narrow_lines": "green",
+}
 
 
 def _get_sdss_filters():
@@ -71,6 +83,16 @@ def _plot_line_component_as_broad(label):
         or ('_br' in base)
         or base.endswith('w')
     )
+
+
+def _spectral_component_color(name, idx):
+    """Return a stable color for a spectral component curve and its band."""
+    component_name = str(name)
+    if component_name.startswith("bal_"):
+        return "red"
+    if component_name in _NAMED_COMPONENT_COLORS:
+        return _NAMED_COMPONENT_COLORS[component_name]
+    return _CUSTOM_COMPONENT_COLORS[idx % len(_CUSTOM_COMPONENT_COLORS)]
 
 
 def posterior_series(fitter, param_names=None, max_vector_elems=2):
@@ -752,14 +774,6 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
     fe_label = 'Fe II (PSF)' if use_psf_space else 'Fe II'
     bc_label = 'Balmer continuum (PSF)' if use_psf_space else 'Balmer continuum'
     line_label = 'total lines (PSF)' if use_psf_space else 'total lines'
-    custom_component_colors = [
-        'darkorange',
-        'crimson',
-        'slateblue',
-        'seagreen',
-        'saddlebrown',
-        'deeppink',
-    ]
     custom_components = list(getattr(fitter, 'custom_components', {}).items())
     custom_line_components = list(getattr(fitter, 'custom_line_components', {}).items())
 
@@ -772,20 +786,6 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
             name value.
         """
         return str(name).startswith('bal_')
-
-    def _custom_component_color(name, idx):
-        """Return the plotting color for one custom component.
-
-        Parameters
-        ----------
-        name : object
-            name value.
-        idx : object
-            idx value.
-        """
-        if _is_bal_component_name(name):
-            return 'red'
-        return custom_component_colors[idx % len(custom_component_colors)]
 
     def _show_component(arr):
         """Return True when a component has finite amplitude worth plotting.
@@ -855,7 +855,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
                 fitter.wave,
                 lo,
                 hi,
-                color=_custom_component_color(name, idx),
+                color=_spectral_component_color(name, idx),
                 alpha=sigma_alpha,
                 linewidth=0,
                 zorder=0,
@@ -920,7 +920,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
     custom_component_zorder = 4.8
     bal_legend_drawn = False
     for idx, (name, model) in enumerate(custom_components + custom_line_components):
-        color = _custom_component_color(name, idx)
+        color = _spectral_component_color(name, idx)
         is_bal_component = _is_bal_component_name(name)
         if is_bal_component:
             label = 'BAL'

--- a/src/jaxsedfit/spectral_plotting.py
+++ b/src/jaxsedfit/spectral_plotting.py
@@ -20,6 +20,10 @@ from .plotting import _STANDARDIZED_RESIDUAL_LABEL, _standardized_residuals
 
 _SDSS_PSF_BANDS = ("u", "g", "r", "i", "z")
 _SDSS_FILTER_CACHE = None
+_BAL_COMPONENT_COLOR = "#D55E00"
+_TOTAL_LINES_COLOR = "#56B4E9"
+_BAL_COMPONENT_LINEWIDTH = 1.8
+_CUSTOM_COMPONENT_LINEWIDTH = 1.4
 _CUSTOM_COMPONENT_COLORS = (
     "darkorange",
     "crimson",
@@ -29,8 +33,8 @@ _CUSTOM_COMPONENT_COLORS = (
     "deeppink",
 )
 _NAMED_COMPONENT_COLORS = {
-    "broad_lines": "red",
-    "narrow_lines": "green",
+    "broad_lines": "#CC79A7",
+    "narrow_lines": "#009E73",
 }
 
 
@@ -89,10 +93,17 @@ def _spectral_component_color(name, idx):
     """Return a stable color for a spectral component curve and its band."""
     component_name = str(name)
     if component_name.startswith("bal_"):
-        return "red"
+        return _BAL_COMPONENT_COLOR
     if component_name in _NAMED_COMPONENT_COLORS:
         return _NAMED_COMPONENT_COLORS[component_name]
     return _CUSTOM_COMPONENT_COLORS[idx % len(_CUSTOM_COMPONENT_COLORS)]
+
+
+def _spectral_component_linewidth(name):
+    """Return a slightly heavier line width for BAL absorption curves."""
+    if str(name).startswith("bal_"):
+        return _BAL_COMPONENT_LINEWIDTH
+    return _CUSTOM_COMPONENT_LINEWIDTH
 
 
 def posterior_series(fitter, param_names=None, max_vector_elems=2):
@@ -288,7 +299,7 @@ def plot_initialization(
         else:
             ax.plot(wave, powerlaw, color="orange", lw=1.5, zorder=5, rasterized=True)
         if _show_component(line):
-            ax.plot(wave, line, color="lightskyblue", lw=1.5, label="lines", zorder=5, rasterized=True)
+            ax.plot(wave, line, color=_TOTAL_LINES_COLOR, lw=1.5, label="lines", zorder=5, rasterized=True)
 
         ax.set_xlim(float(np.nanmin(wave)), float(np.nanmax(wave)))
         y_arrays = [arr[np.isfinite(arr)] for arr in (flux, model, host, powerlaw, line)]
@@ -828,7 +839,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
             'PL': 'orange',
             'FeII': 'teal',
             'Balmer_cont': 'y',
-            'lines': 'lightskyblue',
+            'lines': _TOTAL_LINES_COLOR,
         }
         for key, color in band_colors.items():
             if key not in pred_bands:
@@ -921,6 +932,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
     bal_legend_drawn = False
     for idx, (name, model) in enumerate(custom_components + custom_line_components):
         color = _spectral_component_color(name, idx)
+        linewidth = _spectral_component_linewidth(name)
         is_bal_component = _is_bal_component_name(name)
         if is_bal_component:
             label = 'BAL'
@@ -934,7 +946,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
                 fitter.wave,
                 model,
                 color=color,
-                lw=1.4,
+                lw=linewidth,
                 label=draw_label,
                 zorder=custom_component_zorder,
                 rasterized=True,
@@ -942,13 +954,20 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
             if is_bal_component and draw_label is not None:
                 bal_legend_drawn = True
         else:
-            ax.plot(fitter.wave, model, color=color, lw=1.4, zorder=custom_component_zorder, rasterized=True)
+            ax.plot(
+                fitter.wave,
+                model,
+                color=color,
+                lw=linewidth,
+                zorder=custom_component_zorder,
+                rasterized=True,
+            )
     if len(line_plot) == len(fitter.wave):
         if _show_component(line_plot):
             ax.plot(
                 fitter.wave,
                 line_plot,
-                color='lightskyblue',
+                color=_TOTAL_LINES_COLOR,
                 lw=1.5,
                 label=line_label,
                 zorder=5,
@@ -958,7 +977,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
             ax.plot(
                 fitter.wave,
                 line_plot,
-                color='lightskyblue',
+                color=_TOTAL_LINES_COLOR,
                 lw=1.5,
                 label=line_label,
                 zorder=5,
@@ -1038,7 +1057,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
                     ax.plot(
                         fitter.wave,
                         prof,
-                        color='red',
+                        color=_NAMED_COMPONENT_COLORS["broad_lines"],
                         lw=0.7,
                         alpha=0.35,
                         zorder=3,
@@ -1051,7 +1070,7 @@ def plot_fig(fitter, save_fig_path=None, broad_fwhm=1200, plot_legend=True, ylim
                     ax.plot(
                         fitter.wave,
                         prof,
-                        color='green',
+                        color=_NAMED_COMPONENT_COLORS["narrow_lines"],
                         lw=0.7,
                         alpha=0.25,
                         zorder=3,

--- a/tests/test_diffstar_host.py
+++ b/tests/test_diffstar_host.py
@@ -927,9 +927,32 @@ def test_fit_map_plot_init_plots_both_staged_map_solutions(monkeypatch):
     assert calls[0][1]["include_sed_agn_features"] is True
     assert calls[0][1]["include_spectral_features"] is True
     assert calls[0][1]["include_spectral_lines"] is False
+    assert calls[0][1]["include_spectral_bal"] is False
     assert calls[1][1]["include_sed_agn_features"] is True
     assert calls[1][1]["include_spectral_features"] is True
     assert calls[1][1]["include_spectral_lines"] is True
+    assert calls[1][1]["include_spectral_bal"] is True
+
+
+def test_stage1_map_model_disables_bal_only(monkeypatch):
+    import jaxsedfit.core as core_module
+
+    fitter = JAXSEDFit.__new__(JAXSEDFit)
+    fitter.context = object()
+    captured = {}
+
+    def fake_model(context, **kwargs):
+        captured["context"] = context
+        captured.update(kwargs)
+        return "stage1"
+
+    monkeypatch.setattr(core_module, "grahsp_photometric_model", fake_model)
+
+    assert fitter._continuum_init_model() == "stage1"
+    assert captured["context"] is fitter.context
+    assert captured["include_spectral_features"] is True
+    assert captured["include_spectral_lines"] is False
+    assert captured["include_spectral_bal"] is False
 
 
 def test_joint_dense_mass_blocks_follow_active_sites():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,9 +12,11 @@ from jaxsedfit.config import (
     GalaxyConfig,
     Observation,
     PhotometryData,
+    serialize_config,
 )
 from jaxsedfit.core import JAXSEDFit
 from jaxsedfit.results import FitResult, PredictionResult
+from jaxsedfit.spectral_defaults import build_default_bal_components
 
 
 @pytest.fixture(autouse=True)
@@ -46,6 +48,50 @@ def _minimal_config() -> FitConfig:
             ]
         ),
         galaxy=GalaxyConfig(dsps_ssp_fn="fake.h5", n_wave=32, sfh_n_steps=8),
+    )
+
+
+def test_serialize_config_uses_custom_component_state_when_nested():
+    config = _minimal_config()
+    config.agn.custom_components = build_default_bal_components(
+        np.array([1.0, 2.0, 3.0])
+    )
+
+    serialized = serialize_config(config)
+    component = serialized["agn"]["custom_components"][0]
+
+    assert component["__custom_component__"] is True
+    assert component["name"] == "bal_nv"
+    assert component["evaluate_ref"] == (
+        "jaxsedfit.spectral_model:gaussian_bal_optical_depth_component"
+    )
+    assert "evaluate" not in component
+
+
+def test_bal_custom_components_roundtrip_in_posterior_bundle(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "jaxsedfit.core.build_model_context",
+        lambda config: SimpleNamespace(mw_ebv=0.03),
+    )
+    config = _minimal_config()
+    config.agn.custom_components = build_default_bal_components(
+        np.array([1.0, 2.0, 3.0])
+    )
+    fitter = JAXSEDFit(config)
+    fitter.samples = {"log_stellar_mass": np.array([10.0, 10.2])}
+
+    saved_path = fitter.save(tmp_path)
+    loaded = JAXSEDFit.load(saved_path)
+
+    assert [
+        component.name for component in loaded.config.agn.custom_components
+    ] == ["bal_nv", "bal_siiv", "bal_civ"]
+    assert all(
+        callable(component.evaluate)
+        for component in loaded.config.agn.custom_components
+    )
+    assert loaded.config.agn.custom_components[0].evaluate.__name__ == (
+        "gaussian_bal_optical_depth_component"
     )
 
 

--- a/tests/test_model_assembly.py
+++ b/tests/test_model_assembly.py
@@ -831,6 +831,46 @@ def test_joint_continuum_stage_keeps_feii_and_balmer_but_omits_lines(monkeypatch
     assert not any(name.startswith("spectral_line_fwhm") for name in tr)
 
 
+def test_stage_one_keeps_smooth_features_but_omits_lines_and_bal(monkeypatch):
+    from jaxsedfit.spectral_defaults import build_default_bal_components
+    from jaxsedfit.spectroscopy import make_custom_component
+
+    _patch_ssp(monkeypatch)
+    cfg = _cfg(fit_host=False, spectroscopy_enabled=True)
+    cfg.agn.fit_lines = True
+    cfg.agn.fit_feii = True
+    cfg.agn.fit_balmer_continuum = True
+    additive = make_custom_component(
+        "additive",
+        {"amplitude": dist.Delta(1.0e-3)},
+        lambda wave, params, metadata: jnp.ones_like(wave) * params["amplitude"],
+    )
+    cfg.agn.custom_components = (
+        *build_default_bal_components(np.ones(3)),
+        additive,
+    )
+    context = build_model_context(cfg)
+
+    tr = trace(
+        seed(
+            lambda: grahsp_photometric_model(
+                context,
+                include_sed_agn_features=True,
+                include_spectral_features=True,
+                include_spectral_lines=False,
+                include_spectral_bal=False,
+            ),
+            jax.random.PRNGKey(42),
+        )
+    ).get_trace()
+
+    assert "spectral_feii_norm" in tr
+    assert "spectral_balmer_norm" in tr
+    assert "spectral_custom_additive_model" in tr
+    assert not any(name.startswith("spectral_custom_bal") for name in tr)
+    assert not any(name.startswith("spectral_line_amp") for name in tr)
+
+
 def test_agn_only_context_skips_host_ssp_loading(monkeypatch):
     monkeypatch.setattr("jaxsedfit.preload._SSP_DATA_CACHE", {})
     monkeypatch.setattr("jaxsedfit.preload._HOST_BASIS_CACHE", {})

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -1912,6 +1912,65 @@ def test_spectral_engine_does_not_fix_narrow_width_without_explicit_override(mon
     assert captured["feature_amplitude_scale"] == pytest.approx(2.0)
 
 
+def test_spectral_engine_can_disable_only_bal_custom_components(monkeypatch):
+    from jaxsedfit import spectroscopy
+    captured = {}
+
+    def fake_evaluate_joint_spectral_components(wave_obs, redshift, continuum_mjy, *, config, **kwargs):
+        captured["config"] = config
+        zeros = np.zeros_like(np.asarray(wave_obs, dtype=float))
+        return {
+            "total": np.asarray(continuum_mjy, dtype=float),
+            "continuum": np.asarray(continuum_mjy, dtype=float),
+            "lines": zeros,
+            "line_broad": zeros,
+            "line_narrow": zeros,
+            "feii": zeros,
+            "balmer": zeros,
+        }
+
+    monkeypatch.setattr(
+        spectroscopy,
+        "evaluate_joint_spectral_components",
+        fake_evaluate_joint_spectral_components,
+    )
+    bal = make_custom_component(
+        "bal_civ",
+        {"tau_peak": dist.Delta(1.0)},
+        lambda wave, params, metadata: jnp.ones_like(wave) * params["tau_peak"],
+        metadata={"component_type": "bal_absorption"},
+    )
+    additive = make_custom_component(
+        "additive",
+        {"amplitude": dist.Delta(1.0)},
+        lambda wave, params, metadata: jnp.ones_like(wave) * params["amplitude"],
+    )
+    cfg = FitConfig(
+        observation=Observation(redshift=1.0e-4),
+        photometry=PhotometryData(filter_names=["f1"], fluxes=[1.0], errors=[0.1]),
+        agn=AGNConfig(
+            fit_lines=False,
+            custom_components=(bal, additive),
+        ),
+    )
+    wave = np.asarray([4995.0, 5000.0, 5005.0], dtype=float)
+
+    _evaluate_spectral_components(
+        wave,
+        0.0,
+        np.ones_like(wave),
+        cfg,
+        {"line": {"table": []}},
+        wave,
+        np.zeros_like(wave),
+        include_bal_components=False,
+    )
+
+    assert [component.name for component in captured["config"].custom_components] == [
+        "additive"
+    ]
+
+
 def test_fit_config_mapping_coerces_agn_template_config():
     cfg = fit_config_from_mapping(
         {

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -57,6 +57,7 @@ from jaxsedfit.model import (
     _evaluate_spectral_components,
     _powerlaw_jax,
     _project_local_nebular_line_filters,
+    _project_spectral_custom_state_filters,
     _project_spectral_line_state_filters,
     _project_filters,
     _redshift_to_obs,
@@ -70,6 +71,7 @@ from jaxsedfit.model import (
     spectroscopic_likelihood_weight,
     spectroscopic_log_likelihood,
 )
+from jaxsedfit.spectroscopy import SpectralComponentConfig, make_custom_component
 from jaxsedfit.preload import _build_fixed_igm_jax, _build_igm_cache_jax, _surviving_fraction_for_imf, build_model_context
 from jaxsedfit.filters import load_filter_curve
 from jaxsedfit.preload import (
@@ -260,6 +262,53 @@ def test_spectral_line_state_filter_projection_conserves_flux():
     expected = conversion * 5000.0**2 * np.trapezoid(flambda[inside], dense_wave[inside]) / (wave[-1] - wave[0])
 
     assert projected == pytest.approx(expected, rel=2.0e-3)
+
+
+def _constant_bal_tau_for_filter_test(wave, params, metadata):
+    del metadata
+    return jnp.ones_like(wave) * params["tau_peak"]
+
+
+def test_bal_disk_decrement_is_integrated_on_native_filter_grid():
+    wave = np.linspace(1400.0, 1600.0, 301)
+    transmission = 1.0 - np.abs(wave - 1500.0) / 100.0
+    context = _local_projection_context(wave, transmission)
+    disk_fnu = 2.0 + 0.002 * (wave - 1400.0)
+    bal = make_custom_component(
+        "bal_native",
+        {
+            "tau_peak": dist.Delta(np.log(2.0)),
+            "covering": dist.Delta(0.4),
+        },
+        _constant_bal_tau_for_filter_test,
+        metadata={"component_type": "bal_absorption"},
+    )
+    cfg = SpectralComponentConfig(use_lines=False, custom_components=(bal,))
+    state = {
+        f"custom:{bal.prefix}": {
+            "tau_peak": np.log(2.0),
+            "covering": 0.4,
+        }
+    }
+
+    projected, broad, narrow = _project_spectral_custom_state_filters(
+        context,
+        state,
+        0.0,
+        cfg,
+        bal_continuum_mjy=jnp.asarray(disk_fnu[None, :]),
+    )
+
+    bal_decrement_fnu = disk_fnu * (0.8 - 1.0)
+    conversion = 1.0e-10 / 299792458.0 * 1.0e29
+    flambda = bal_decrement_fnu / (conversion * wave**2)
+    expected_flambda = np.trapezoid(flambda * transmission, wave) / np.trapezoid(
+        transmission, wave
+    )
+    expected = conversion * float(context.filter_effective_wavelength_jax[0]) ** 2 * expected_flambda
+    assert float(projected[0]) == pytest.approx(expected, rel=1.0e-10)
+    np.testing.assert_allclose(broad, 0.0)
+    np.testing.assert_allclose(narrow, 0.0)
 
 
 def _dense_nebular_line_filter_flux(context, *, line_wave, line_lumin, width_kms, luminosity_distance_m=1.0e20):
@@ -2527,6 +2576,7 @@ def test_plot_spectrum_adapts_joint_predictive(monkeypatch):
     assert "jaxsedfit_torus" in captured["custom_components"]
     assert "jaxsedfit_host_dust" in captured["custom_components"]
     assert "bal_civ" in captured["custom_components"]
+    assert np.nanmax(captured["custom_components"]["bal_civ"]) < 0.0
     assert "spectral_custom_bal_civ_model" in captured["extra_return_sites"]
     assert "jaxsedfit_sed_lines" not in captured["custom_components"]
     assert "jaxsedfit_nebular_lines" not in captured["custom_components"]
@@ -2552,6 +2602,9 @@ def test_plot_spectrum_adapts_joint_predictive(monkeypatch):
     assert "PL" in captured["pred_bands"]
     assert "jaxsedfit_torus" in captured["pred_bands"]
     assert "bal_civ" in captured["pred_bands"]
+    bal_lo, bal_hi = captured["pred_bands"]["bal_civ"]
+    assert np.nanmax(bal_lo) < 0.0
+    assert np.nanmax(bal_hi) < 0.0
     assert "broad_lines" in captured["pred_bands"]
     assert "narrow_lines" in captured["pred_bands"]
     assert captured["use_psf_phot"] is True

--- a/tests/test_model_helpers.py
+++ b/tests/test_model_helpers.py
@@ -2461,6 +2461,14 @@ def test_plot_spectrum_adapts_joint_predictive(monkeypatch):
             filter_names=["W1", "r_sdss", "u_sdss", "g_sdss", "z_sdss", "i_sdss"],
             photometry_method=["catalog", "psf", "psf", "catalog", "psf", "psf"],
         ),
+        agn=SimpleNamespace(
+            custom_components=(
+                SimpleNamespace(
+                    output_name="bal_civ",
+                    deterministic_site_name="custom_bal_civ_model",
+                ),
+            ),
+        ),
     )
     fitter.context = SimpleNamespace(
         fluxes=np.asarray([1.0, 2.0, 4.0, 3.0, 5.0, -1.0]),
@@ -2472,28 +2480,35 @@ def test_plot_spectrum_adapts_joint_predictive(monkeypatch):
         spec_mask=np.asarray([True, True, True]),
         spec_spectrum_index=np.asarray([0, 0, 0]),
     )
-    fitter.predict = lambda posterior="latest": {
-        "obs_wave": np.asarray([[4000.0, 5000.0, 6000.0], [4000.0, 5000.0, 6000.0]]),
-        "pred_spectrum_fluxes": np.asarray([[1.1, 2.2, 3.3], [1.3, 2.4, 3.5]]),
-        "spec_host_model_fluxes": np.asarray([[0.2, 0.3, 0.4], [0.25, 0.35, 0.45]]),
-        "spec_disk_model_fluxes": np.asarray([[0.5, 0.6, 0.7], [0.55, 0.65, 0.75]]),
-        "spec_torus_model_fluxes": np.asarray([[0.05, 0.06, 0.07], [0.055, 0.065, 0.075]]),
-        "spectral_continuum_model": np.asarray([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),
-        "spectral_line_model": np.asarray([[0.1, 0.2, 0.3], [0.3, 0.4, 0.5]]),
-        "spectral_line_model_aperture": np.asarray([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]]),
-        "spectral_line_model_broad": np.asarray([[0.6, 0.7, 0.8], [0.8, 0.9, 1.0]]),
-        "spectral_line_model_narrow": np.asarray([[0.4, 0.3, 0.2], [0.6, 0.5, 0.4]]),
-        "spectral_line_model_narrow_aperture": np.asarray([[0.2, 0.15, 0.1], [0.3, 0.25, 0.2]]),
-        "spectrum_scale_fit": np.asarray([2.0, 2.0]),
-        "spectrum_host_capture_fraction": np.asarray([0.5, 0.5]),
-        "host_obs_sed": np.asarray([[1.0e-20, 2.0e-20, 3.0e-20], [1.0e-20, 2.0e-20, 3.0e-20]]),
-        "disk_obs_sed": np.asarray([[2.0e-20, 2.0e-20, 2.0e-20], [2.0e-20, 2.0e-20, 2.0e-20]]),
-        "torus_obs_sed": np.asarray([[0.5e-20, 0.5e-20, 0.5e-20], [0.5e-20, 0.5e-20, 0.5e-20]]),
-        "dust_obs_sed": np.asarray([[0.1e-20, 0.1e-20, 0.1e-20], [0.1e-20, 0.1e-20, 0.1e-20]]),
-        "line_obs_sed": np.zeros((2, 3)),
-        "feii_obs_sed": np.zeros((2, 3)),
-        "nebular_lines_obs_sed": np.asarray([[0.2e-20, 0.3e-20, 0.2e-20], [0.2e-20, 0.3e-20, 0.2e-20]]),
-    }
+    def _fake_predict(posterior="latest", *, extra_return_sites=()):
+        captured["extra_return_sites"] = tuple(extra_return_sites)
+        return {
+            "obs_wave": np.asarray([[4000.0, 5000.0, 6000.0], [4000.0, 5000.0, 6000.0]]),
+            "pred_spectrum_fluxes": np.asarray([[1.1, 2.2, 3.3], [1.3, 2.4, 3.5]]),
+            "spec_host_model_fluxes": np.asarray([[0.2, 0.3, 0.4], [0.25, 0.35, 0.45]]),
+            "spec_disk_model_fluxes": np.asarray([[0.5, 0.6, 0.7], [0.55, 0.65, 0.75]]),
+            "spec_torus_model_fluxes": np.asarray([[0.05, 0.06, 0.07], [0.055, 0.065, 0.075]]),
+            "spectral_continuum_model": np.asarray([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),
+            "spectral_line_model": np.asarray([[0.1, 0.2, 0.3], [0.3, 0.4, 0.5]]),
+            "spectral_line_model_aperture": np.asarray([[1.0, 1.0, 1.0], [3.0, 3.0, 3.0]]),
+            "spectral_line_model_broad": np.asarray([[0.6, 0.7, 0.8], [0.8, 0.9, 1.0]]),
+            "spectral_line_model_narrow": np.asarray([[0.4, 0.3, 0.2], [0.6, 0.5, 0.4]]),
+            "spectral_line_model_narrow_aperture": np.asarray([[0.2, 0.15, 0.1], [0.3, 0.25, 0.2]]),
+            "spectral_custom_bal_civ_model": np.asarray(
+                [[-0.1, -0.2, -0.1], [-0.2, -0.3, -0.2]]
+            ),
+            "spectrum_scale_fit": np.asarray([2.0, 2.0]),
+            "spectrum_host_capture_fraction": np.asarray([0.5, 0.5]),
+            "host_obs_sed": np.asarray([[1.0e-20, 2.0e-20, 3.0e-20], [1.0e-20, 2.0e-20, 3.0e-20]]),
+            "disk_obs_sed": np.asarray([[2.0e-20, 2.0e-20, 2.0e-20], [2.0e-20, 2.0e-20, 2.0e-20]]),
+            "torus_obs_sed": np.asarray([[0.5e-20, 0.5e-20, 0.5e-20], [0.5e-20, 0.5e-20, 0.5e-20]]),
+            "dust_obs_sed": np.asarray([[0.1e-20, 0.1e-20, 0.1e-20], [0.1e-20, 0.1e-20, 0.1e-20]]),
+            "line_obs_sed": np.zeros((2, 3)),
+            "feii_obs_sed": np.zeros((2, 3)),
+            "nebular_lines_obs_sed": np.asarray([[0.2e-20, 0.3e-20, 0.2e-20], [0.2e-20, 0.3e-20, 0.2e-20]]),
+        }
+
+    fitter.predict = _fake_predict
 
     fig = fitter.plot_spectrum(show_plot=False, plot_residual=False)
 
@@ -2511,6 +2526,8 @@ def test_plot_spectrum_adapts_joint_predictive(monkeypatch):
     )
     assert "jaxsedfit_torus" in captured["custom_components"]
     assert "jaxsedfit_host_dust" in captured["custom_components"]
+    assert "bal_civ" in captured["custom_components"]
+    assert "spectral_custom_bal_civ_model" in captured["extra_return_sites"]
     assert "jaxsedfit_sed_lines" not in captured["custom_components"]
     assert "jaxsedfit_nebular_lines" not in captured["custom_components"]
     assert set(captured["custom_line_components"]) == {"broad_lines", "narrow_lines"}
@@ -2534,6 +2551,7 @@ def test_plot_spectrum_adapts_joint_predictive(monkeypatch):
     assert "host" in captured["pred_bands"]
     assert "PL" in captured["pred_bands"]
     assert "jaxsedfit_torus" in captured["pred_bands"]
+    assert "bal_civ" in captured["pred_bands"]
     assert "broad_lines" in captured["pred_bands"]
     assert "narrow_lines" in captured["pred_bands"]
     assert captured["use_psf_phot"] is True

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,10 +2,8 @@ from pathlib import Path
 import sys
 import types
 
-import matplotlib
-
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 import numpy as np
 import pytest
 
@@ -144,6 +142,7 @@ def test_plot_fit_sed_writes_output(tmp_path):
         (0, 8),
         (0, 8),
     ]
+    FigureCanvasAgg(fig)
     fig.canvas.draw()
     renderer = fig.canvas.get_renderer()
     for annotation in fig.axes[0].texts[:3]:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -12,6 +12,7 @@ from jaxsedfit.plotting import (
     _bridged_jaxsedfit_agn_lines,
     _grouped_trace_samples,
     _median_effective_variance,
+    _place_overlapping_band_annotations,
     plot_corner,
     plot_fit_sed,
     plot_trace,
@@ -129,8 +130,60 @@ def test_plot_fit_sed_writes_output(tmp_path):
     assert np.array_equal(agn_line_curves[0].get_xdata(), wave)
     assert len([line for line in fig.axes[0].lines if line.get_label() == "Fe II"]) == 1
     assert len([line for line in fig.axes[0].lines if line.get_label() == "Balmer cont."]) == 1
+    assert [text.get_text() for text in fig.axes[0].texts[:3]] == ["f1", "f2", "f3"]
+    for annotation in fig.axes[0].texts[:3]:
+        assert annotation.get_zorder() == 20
+        assert annotation.get_bbox_patch().get_alpha() == pytest.approx(0.62)
+        assert annotation.get_rotation() == pytest.approx(90.0)
+        assert annotation.get_rotation_mode() == "default"
+    assert [annotation.get_position() for annotation in fig.axes[0].texts[:3]] == [
+        (0, 8),
+        (0, 8),
+        (0, 8),
+    ]
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    for annotation in fig.axes[0].texts[:3]:
+        point_y = fig.axes[0].transData.transform(annotation.xy)[1]
+        assert annotation.get_window_extent(renderer).y0 > point_y
     assert output.exists()
     assert output.stat().st_size > 0
+
+
+def test_colliding_band_annotations_follow_point_height():
+    fig, ax = plt.subplots()
+    annotations = [
+        ax.annotate(
+            label,
+            point,
+            xytext=(0, 8),
+            textcoords="offset points",
+            rotation=90,
+        )
+        for label, point in (
+            ("near_lower", (0.5000, 0.3)),
+            ("near_upper", (0.5001, 0.7)),
+            ("far", (0.8, 0.5)),
+        )
+    ]
+
+    _place_overlapping_band_annotations(fig, annotations)
+
+    assert [annotation.get_position() for annotation in annotations] == [
+        (0, -8),
+        (0, 8),
+        (0, 8),
+    ]
+    assert [annotation.get_verticalalignment() for annotation in annotations] == [
+        "top",
+        "bottom",
+        "bottom",
+    ]
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    below_point_y = ax.transData.transform(annotations[0].xy)[1]
+    assert annotations[0].get_window_extent(renderer).y1 < below_point_y
+    plt.close(fig)
 
 
 def test_plot_fit_sed_can_disable_band_annotations(tmp_path):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,6 +2,9 @@ from pathlib import Path
 import sys
 import types
 
+import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -18,7 +18,11 @@ from jaxsedfit.plotting import (
     plot_fit_sed,
     plot_trace,
 )
-from jaxsedfit.spectral_plotting import _spectral_component_color
+from jaxsedfit.spectral_plotting import (
+    _TOTAL_LINES_COLOR,
+    _spectral_component_color,
+    _spectral_component_linewidth,
+)
 
 
 def test_joint_line_bridge_rescales_native_jaxsedfit_shape():
@@ -58,9 +62,12 @@ def test_component_style_separates_feii_from_agn_lines():
 
 def test_spectral_line_colors_are_stable_and_semantic():
     for index in range(12):
-        assert _spectral_component_color("broad_lines", index) == "red"
-        assert _spectral_component_color("narrow_lines", index) == "green"
-    assert _spectral_component_color("bal_civ", 2) == "red"
+        assert _spectral_component_color("broad_lines", index) == "#CC79A7"
+        assert _spectral_component_color("narrow_lines", index) == "#009E73"
+    assert _spectral_component_color("bal_civ", 2) == "#D55E00"
+    assert _TOTAL_LINES_COLOR == "#56B4E9"
+    assert _spectral_component_linewidth("bal_civ") == pytest.approx(1.8)
+    assert _spectral_component_linewidth("broad_lines") == pytest.approx(1.4)
 
 
 def test_plot_fit_sed_writes_output(tmp_path):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -18,6 +18,7 @@ from jaxsedfit.plotting import (
     plot_fit_sed,
     plot_trace,
 )
+from jaxsedfit.spectral_plotting import _spectral_component_color
 
 
 def test_joint_line_bridge_rescales_native_jaxsedfit_shape():
@@ -53,6 +54,13 @@ def test_component_style_separates_feii_from_agn_lines():
 
     assert "feii_obs_sed" not in styles["AGN lines"]
     assert styles["Fe II"] == ("feii_obs_sed",)
+
+
+def test_spectral_line_colors_are_stable_and_semantic():
+    for index in range(12):
+        assert _spectral_component_color("broad_lines", index) == "red"
+        assert _spectral_component_color("narrow_lines", index) == "green"
+    assert _spectral_component_color("bal_civ", 2) == "red"
 
 
 def test_plot_fit_sed_writes_output(tmp_path):

--- a/tests/test_spectral_components.py
+++ b/tests/test_spectral_components.py
@@ -11,6 +11,8 @@ from jaxsedfit.spectroscopy import (
     make_custom_component,
     make_custom_line_component,
 )
+from jaxsedfit.spectral_components import _apply_bal_absorption
+from jaxsedfit.spectral_defaults import build_default_bal_components
 from jaxsedfit.spectroscopy import (
     NORMAL_LOGNORMAL_STANDARDIZATION,
     build_spectral_prior_config as build_default_prior_config,
@@ -19,6 +21,173 @@ from jaxsedfit.spectroscopy import (
 
 def _constant_custom_component(wave, params, metadata):
     return jnp.ones_like(wave) * params["amplitude"] * metadata.get("scale", 1.0)
+
+
+def _constant_bal_optical_depth(wave, params, metadata):
+    del metadata
+    return jnp.ones_like(wave) * params["tau_peak"]
+
+
+def _fixed_bal_component(name, tau_peak, covering):
+    return make_custom_component(
+        name,
+        {
+            "tau_peak": dist.Delta(float(tau_peak)),
+            "covering": dist.Delta(float(covering)),
+        },
+        _constant_bal_optical_depth,
+        metadata={"component_type": "bal_absorption"},
+    )
+
+
+def test_joint_bal_identity_partial_covering_and_negative_decrement():
+    wave_obs = np.linspace(1400.0, 1600.0, 9)
+    continuum = np.full_like(wave_obs, 7.0)
+    disk = np.full_like(wave_obs, 3.0)
+
+    identity = seed(evaluate_joint_spectral_components, jax.random.PRNGKey(100))(
+        wave_obs,
+        0.0,
+        continuum,
+        config=SpectralComponentConfig(
+            use_lines=False,
+            custom_components=(_fixed_bal_component("bal_zero", 0.0, 0.4),),
+        ),
+        bal_continuum_mjy=disk,
+    )
+    np.testing.assert_allclose(identity["bal_transmission"], 1.0)
+    np.testing.assert_allclose(identity["bal_decrement"], 0.0)
+    np.testing.assert_allclose(identity["total"], continuum)
+
+    absorbed = seed(evaluate_joint_spectral_components, jax.random.PRNGKey(101))(
+        wave_obs,
+        0.0,
+        continuum,
+        config=SpectralComponentConfig(
+            use_lines=False,
+            custom_components=(
+                _fixed_bal_component("bal_partial", np.log(2.0), 0.4),
+            ),
+        ),
+        bal_continuum_mjy=disk,
+    )
+    expected_transmission = 0.8
+    np.testing.assert_allclose(absorbed["bal_transmission"], expected_transmission)
+    np.testing.assert_allclose(absorbed["bal_decrement"], -0.6)
+    np.testing.assert_allclose(absorbed["custom"]["bal_partial"], -0.6)
+    np.testing.assert_allclose(absorbed["total"], 6.4)
+
+
+def test_joint_multiple_bal_transmissions_multiply():
+    wave_obs = np.linspace(1400.0, 1600.0, 9)
+    disk = np.full_like(wave_obs, 3.0)
+    cfg = SpectralComponentConfig(
+        use_lines=False,
+        custom_components=(
+            _fixed_bal_component("bal_a", np.log(2.0), 0.4),
+            _fixed_bal_component("bal_b", np.log(3.0), 0.5),
+        ),
+    )
+    result = seed(evaluate_joint_spectral_components, jax.random.PRNGKey(102))(
+        wave_obs,
+        0.0,
+        np.full_like(wave_obs, 7.0),
+        config=cfg,
+        bal_continuum_mjy=disk,
+    )
+
+    expected_transmission = 0.8 * (2.0 / 3.0)
+    np.testing.assert_allclose(result["bal_transmission"], expected_transmission)
+    np.testing.assert_allclose(result["bal_decrement"], 3.0 * (expected_transmission - 1.0))
+    np.testing.assert_allclose(
+        result["custom"]["bal_a"] + result["custom"]["bal_b"],
+        result["bal_decrement"],
+    )
+    np.testing.assert_allclose(result["total"], 7.0 + 3.0 * (expected_transmission - 1.0))
+
+
+def test_bal_absorption_leaves_host_torus_and_narrow_components_unchanged():
+    wave = jnp.arange(4.0)
+    bal = _fixed_bal_component("bal", np.log(2.0), 0.5)
+    additive = make_custom_component(
+        "additive", {"amplitude": dist.Delta(1.0)}, _constant_custom_component
+    )
+    broad = make_custom_line_component(
+        "custom_broad",
+        {"amplitude": dist.Delta(3.0)},
+        _constant_custom_component,
+        line_kind="broad",
+    )
+    narrow = make_custom_line_component(
+        "custom_narrow",
+        {"amplitude": dist.Delta(5.0)},
+        _constant_custom_component,
+        line_kind="narrow",
+    )
+    cfg = SpectralComponentConfig(
+        use_lines=False,
+        custom_components=(bal, additive),
+        custom_line_components=(broad, narrow),
+    )
+    state = {
+        f"custom:{bal.prefix}": {"tau_peak": np.log(2.0), "covering": 0.5},
+        f"custom:{additive.prefix}": {"amplitude": 1.0},
+        f"custom:{broad.prefix}": {"amplitude": 3.0},
+        f"custom:{narrow.prefix}": {"amplitude": 5.0},
+    }
+    raw_custom = {
+        bal.output_name: jnp.full_like(wave, np.log(2.0)),
+        additive.output_name: jnp.ones_like(wave),
+        broad.output_name: jnp.full_like(wave, 3.0),
+        narrow.output_name: jnp.full_like(wave, 5.0),
+    }
+    result = _apply_bal_absorption(
+        wave,
+        raw_custom,
+        state,
+        cfg,
+        line_broad=jnp.full_like(wave, 2.0),
+        line_narrow=jnp.full_like(wave, 4.0),
+        feii=jnp.full_like(wave, 6.0),
+        balmer=jnp.full_like(wave, 8.0),
+        bal_continuum_mjy=jnp.full_like(wave, 10.0),
+    )
+
+    np.testing.assert_allclose(result["bal_transmission"], 0.75)
+    np.testing.assert_allclose(result["line_broad"], (2.0 + 3.0) * 0.75)
+    np.testing.assert_allclose(result["line_narrow"], 4.0 + 5.0)
+    np.testing.assert_allclose(result["feii"], 6.0 * 0.75)
+    np.testing.assert_allclose(result["balmer"], 8.0 * 0.75)
+    np.testing.assert_allclose(result["custom"]["additive"], 0.75)
+    np.testing.assert_allclose(result["custom"]["custom_narrow"], 5.0)
+    # Host and torus are part of the external continuum but absent from the
+    # compact ``bal_continuum_mjy`` reference, so this decrement cannot touch them.
+    np.testing.assert_allclose(result["custom_continuum"], 0.75 - 2.5)
+
+
+def test_joint_default_bal_components_use_one_shared_physical_site_set():
+    components = build_default_bal_components(np.ones(3))
+    tr = trace(seed(evaluate_joint_spectral_components, jax.random.PRNGKey(103))).get_trace(
+        wave_obs=np.linspace(1100.0, 1650.0, 64),
+        redshift=0.0,
+        continuum_mjy=np.ones(64),
+        config=SpectralComponentConfig(use_lines=False, custom_components=components),
+    )
+
+    for name in (
+        "spectral_custom_bal_v_out",
+        "spectral_custom_bal_tau_peak",
+        "spectral_custom_bal_covering",
+        "spectral_custom_bal_fwhm_kms",
+    ):
+        assert name in tr
+        assert tr[name]["type"] == "sample"
+    for transition in ("nv", "siiv", "civ"):
+        assert f"spectral_custom_bal_{transition}_shape_power" in tr
+        assert f"spectral_custom_bal_{transition}_v_out" not in tr
+        assert f"spectral_custom_bal_{transition}_tau_peak" not in tr
+        assert f"spectral_custom_bal_{transition}_covering" not in tr
+        assert f"spectral_custom_bal_{transition}_fwhm_kms" not in tr
 
 
 def test_evaluate_joint_spectral_components_uses_external_continuum():


### PR DESCRIPTION
## Summary

- preserve custom component state while recursively serializing nested dataclass configuration, allowing BAL configuration to round-trip through saved posterior bundles
- render photometry band labels vertically with translucent, collision-aware boxes and pass custom BAL curves with posterior uncertainty into spectrum plots
- replace the joint engine positive additive BAL optical-depth profile with the physical partial-covering transmission `T_i = 1 - C_i (1 - exp(-tau_i))`, multiplied across transitions
- share BAL velocity, optical depth, covering fraction, and FWHM across N V, Si IV, and C IV while retaining transition-specific shape parameters
- apply the same sampled transmission to the compact AGN disk, additive AGN custom continuum, Fe II, Balmer continuum, and broad lines in the spectrum, continuous SED, and native-filter photometry; host, torus, and narrow lines remain unattenuated
- expose combined transmission/decrement diagnostics and negative per-transition removed-flux curves whose sum is exact even for overlapping troughs
- disable BAL components and built-in emission lines only during stage-one MAP optimization and its initialization plots; Fe II, Balmer continuum, and ordinary smooth custom components remain active, while final MAP and posterior inference retain the full configured model
- use stable semantic spectrum colors: BAL orange and slightly thicker, broad lines pink, narrow lines green, and aggregate lines blue, including matching uncertainty bands

## Compatibility warning

Existing BAL posterior bundles remain structurally loadable, but every bundle produced before this multiplicative correction encoded BAL optical depth as positive additive flux and is scientifically invalid. Those objects must be refitted. This explicitly includes all `aug31_def_bal` bundles.

## Verification

- complete suite: `456 passed, 6 skipped`
- exact fixed-parameter tests cover zero-depth identity, partial covering, multiple-transmission products, negative decrements, shared sites, selective attenuation, additive custom components, and native-filter quadrature
- staged-MAP tests verify Fe II, Balmer continuum, and ordinary custom components remain active while BAL and built-in emission lines are absent from stage one; the final full model enables all configured components
- plotting tests require negative BAL medians and uncertainty bands, stable semantic component colors and widths, and an Agg backend so CI is backend-independent
- fresh reduced QVC fit for object `1425653` used an isolated `/tmp/jaxsedfit_bal_fix_smoke_1425653` output and did not reuse or overwrite `aug31_def_bal`
- smoke fit completed with zero divergences; posterior BAL transmission reached `0.7955`, all N V/Si IV/C IV diagnostic curves were non-positive, and the median native-filter disk decrement reached about `-0.00110 mJy` in `r_sdss`
- the regenerated spectrum plot shows the BAL curve below zero as removed flux; the logarithmic joint SED reflects BAL through its attenuated AGN and total curves
